### PR TITLE
Change the git clone url in the README to a HTTPS endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Installation
 
 .. code-block:: bash
 
-    git clone git@github.com:brutasse/graphite-api.git
+    git clone https://github.com/brutasse/graphite-api.git
     cd graphite-api
     sudo python setup.py install
 


### PR DESCRIPTION
Nothing related to security; I just did not look and blindly tried to clone the ssh private url and failed.  I imagine others could run into it too.
