### PR TITLE
Fixed exception raised when using maxDataPoints.

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -179,7 +179,7 @@ def prune_datapoints(series, max_datapoints, start, end):
     time_range = end - start
     points = time_range // series.step
     if max_datapoints < points:
-        values_per_point = math.ceil(float(points) / float(max_datapoints))
+        values_per_point = int(math.ceil(float(points) / float(max_datapoints)))
         seconds_per_point = values_per_point * series.step
         nudge = (
             seconds_per_point

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -33,3 +33,9 @@ class RenderTest(TestCase):
         end = data[0]['datapoints'][-4:]
         self.assertEqual(
             end, [[None, ts - 3], [0.5, ts - 2], [0.4, ts - 1], [0.6, ts]])
+
+        response = self.app.get(url, query_string={'target': 'test',
+                                                   'maxDataPoints': 2,
+                                                   'format': 'json'})
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(len(data[0]['datapoints']), 2)


### PR DESCRIPTION
When requesting to limit the number of points returned by
the `/render` resource, the following exception is raised:

```
TypeError: slice indices must be integers or None or have an __index__ method
```

This is due because math.ceil returns a float value but
the remaining of `prune_datapoints` function expects to deal
with integers.
