### PR TITLE
Log the queries received by the Whisper finder

### DIFF
--- a/graphite_api/finders/whisper.py
+++ b/graphite_api/finders/whisper.py
@@ -19,7 +19,7 @@ class WhisperFinder(object):
         self.directories = config['whisper']['directories']
 
     def find_nodes(self, query):
-        self.log.debug("find_nodes", start=query.startTime, end=query.endTime, rangeInMins=(end-start)/60, pattern=query.pattern)
+        self.log.debug("find_nodes", start=query.startTime, end=query.endTime, rangeInMins=(query.endTime-query.startTime)/60, pattern=query.pattern)
         clean_pattern = query.pattern.replace('\\', '')
         pattern_parts = clean_pattern.split('.')
 


### PR DESCRIPTION
Log information about the queries received by the Whisper finder:
- startTime
- endTime
- rangeInMins
- pattern

For example:

```
{"start": 1400162254, "rangeInMins": 60, "end": 1400165854, "pattern": "*.agents.*.metricsReceived", "event": "find_nodes"}
```
