### PR TITLE
allow loading statsd object for instrumentation

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -94,6 +94,25 @@ Extra sections
 .. _Flask-Cache: http://pythonhosted.org/Flask-Cache/
 .. _Graphite-Influxdb: https://github.com/vimeo/graphite-influxdb
 
+*statsd*
+  Attaches a statsd object to the application, which can be used for
+  instrumentation. Currently graphite-api itself doesn't use this,
+  but some backends do, like `Graphite-Influxdb`_.
+
+  Example::
+
+      statsd:
+          host: 'statsd_host'
+          port: 8125  # not needed if default
+
+  .. note::
+
+        This requires the statsd module.
+
+            $ pip install statsd
+
+.. _Graphite-Influxdb: https://github.com/vimeo/graphite-influxdb
+
 *allowed_origins*
 
   Allows you to do cross-domain (CORS) requests to the Graphite API. Say you

--- a/graphite_api/config.py
+++ b/graphite_api/config.py
@@ -97,6 +97,11 @@ def configure(app):
         cache.init_app(app)
         app.cache = cache
 
+    if 'statsd' in config:
+        from statsd import StatsClient
+        c = config['statsd']
+        app.statsd = StatsClient(c['host'], c.get('port', 8125))
+
     finders = []
     for finder in config['finders']:
         finders.append(load_by_path(finder)(config))


### PR DESCRIPTION
this also includes the cache addition, #28
graphite-influxdb leverages this for internal instrumentation.
