### PR TITLE
fix divison by zero when determining xStep when rendering

### DIFF
--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -1244,7 +1244,7 @@ class LineGraph(Graph):
         for series in self.data:
             numberOfDataPoints = self.timeRange / series.step
             minXStep = float(self.params.get('minXStep', 1.0))
-            divisor = self.timeRange / series.step
+            divisor = self.timeRange / series.step or 1
             bestXStep = numberOfPixels / divisor
             if bestXStep < minXStep:
                 drawableDataPoints = int(numberOfPixels / minXStep)


### PR DESCRIPTION
This one fixes https://github.com/brutasse/graphite-api/issues/64