### PR TITLE
Sort nodes by path in render

### DIFF
--- a/graphite_api/storage.py
+++ b/graphite_api/storage.py
@@ -30,7 +30,7 @@ class Store(object):
         # Reduce matching nodes for each path to a minimal set
         found_branch_nodes = set()
 
-        for path, nodes in nodes_by_path.items():
+        for path, nodes in sorted(nodes_by_path.items(), key=lambda k: k[0]):
             leaf_nodes = set()
 
             # First we dispense with the BranchNodes

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -349,3 +349,26 @@ class RenderTest(TestCase):
             self.assertEqual(data, [{'datapoints': [
                 [None, start + i + 1] for i in range(60)
             ], 'target': 'test'}])
+
+    def test_sorted(self):
+        for db in (
+            ('test', 'foo.wsp'),
+            ('test', 'welp.wsp'),
+            ('test', 'baz.wsp'),
+        ):
+            db_path = os.path.join(WHISPER_DIR, *db)
+            if not os.path.exists(os.path.dirname(db_path)):
+                os.makedirs(os.path.dirname(db_path))
+            whisper.create(db_path, [(1, 60)])
+
+        response = self.app.get(self.url, query_string={'rawData': '1',
+                                                        'target': 'test.*'})
+        dses = response.data.decode('utf-8').strip().split("\n")
+
+        paths = []
+        for ds in dses:
+            info, data = ds.strip().split('|', 1)
+            path, start, stop, step = info.split(',')
+            paths.append(path)
+
+        self.assertEqual(paths, ['test.baz', 'test.foo', 'test.welp'])


### PR DESCRIPTION
This matches the graphite-web behavior.  This way colors will stay the same and be consistent across multiple graphs.
