### PR TITLE
post-install script fails on wheezy with python2

### DIFF
--- a/fpm/conf/post-install
+++ b/fpm/conf/post-install
@@ -2,9 +2,16 @@
 
 set -e
 
-# Create bytecode
-python -m compileall /usr/share/python/graphite/lib > /dev/null || true
-python -O -m compileall /usr/share/python/graphite/lib > /dev/null || true
+pythonver=$(python --version 2>&1 | awk -F'.' '{print $1}')
+
+# Create bytecode
+if [[ x$pythonver == 'xPython 2' ]]; then
+	python -m compileall /usr/share/python/graphite/lib > /dev/null || true
+	python -O -m compileall /usr/share/python/graphite/lib > /dev/null || true
+else
+	python -m compileall /usr/share/python/graphite/lib > /dev/null
+	python -O -m compileall /usr/share/python/graphite/lib > /dev/null
+fi
 
 # Create user if it doesn't exist
 if ! id graphite > /dev/null 2>&1 ; then


### PR DESCRIPTION
After building this package on wheezy with python2, I found that the post-install script exits 1:

```
Setting up graphite-api (1.0.1-1417544560) ...
dpkg: error processing graphite-api (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 graphite-api
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

This was when compiling the bytecode:

```
root@host:/var/lib/dpkg/info# bash -x ./graphite-api.postinst
+ set -e
+ python -m compileall /usr/share/python/graphite/lib
root@host:/var/lib/dpkg/info# echo $?
1
```

This is due to a Python3 file inside the Raven project, which is only imported when the interpreter is Python3:

```
root@host:/var/lib/dpkg/info# python -m compileall /usr/share/python/graphite/lib
[...]
Compiling /usr/share/python/graphite/lib/python2.7/site-packages/raven/transport/aiohttp.py ...
SyntaxError: ('invalid syntax', ('/usr/share/python/graphite/lib/python2.7/site-packages/raven/transport/aiohttp.py', 30, 37, '    def __init__(self, parsed_url, *, verify_ssl=True, resolve=True,\n'))
[...]
```

Background is here: https://github.com/getsentry/raven-python/issues/496

I'm not sure of the best way around this, so I've added an `|| true` to the bytecode compile when running under python2, as the rest of the files still compile successfully.
