### PR TITLE
Skip metrics with empty timestamp

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2914,6 +2914,9 @@ def summarize(requestContext, seriesList, intervalString, func='sum',
         datapoints = zip_longest(timestamps, series)
 
         for timestamp, value in datapoints:
+            if timestamp is None:
+                continue
+
             if alignToFrom:
                 bucketInterval = int((timestamp - series.start) / interval)
             else:


### PR DESCRIPTION
For some reason, I'm seeing timestamp, value tuples of (None, None)
consistently as the last item in the list on returns from cyanite.  Skip
bad timestamps defensively.

Signed-off-by: Stephen Gran steve@lobefin.net
