### PR TITLE
fix summarize 500 and also add some guards.

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2909,11 +2909,13 @@ def summarize(requestContext, seriesList, intervalString, func='sum',
     for series in seriesList:
         buckets = {}
 
-        timestamps = range(int(series.start), int(series.end),
+        timestamps = range(int(series.start), int(series.end) + 1,
                            int(series.step))
         datapoints = zip_longest(timestamps, series)
 
         for timestamp, value in datapoints:
+            if timestamp is None:
+                continue
             if alignToFrom:
                 bucketInterval = int((timestamp - series.start) / interval)
             else:

--- a/graphite_api/middleware.py
+++ b/graphite_api/middleware.py
@@ -18,6 +18,7 @@ class CORS(object):
         if netloc in self.origins or '*' in self.origins:
             allow_origin = [
                 ('Access-Control-Allow-Origin', origin),
+                ('Access-Control-Allow-Headers', 'origin,authorization, accept'),
                 ('Access-Control-Allow-Credentials', 'true'),
             ]
             if environ['REQUEST_METHOD'] == 'OPTIONS':


### PR DESCRIPTION
if len(timestamps) = len(series) - 1, then the code breaks and returns 500 to client.

This also fix https://github.com/brutasse/graphite-api/pull/83