### PR TITLE
Added tzinfo to requestContext fields

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -325,6 +325,7 @@ def render():
     context = {
         'startTime': request_options['startTime'],
         'endTime': request_options['endTime'],
+        'tzinfo': request_options['tzinfo'],
         'data': [],
     }
 

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2711,14 +2711,16 @@ def smartSummarize(requestContext, seriesList, intervalString, func='sum'):
 
     # Adjust the start time to fit an entire day for intervals >= 1 day
     requestContext = requestContext.copy()
+    # ISSUE #51: Added tzinfo to requestContext in graphite_api/app.py:328
+    tzinfo = requestContext.get('tzinfo', None)
     s = requestContext['startTime']
     if interval >= DAY:
-        requestContext['startTime'] = datetime(s.year, s.month, s.day)
+        requestContext['startTime'] = datetime(s.year, s.month, s.day, tzinfo=tzinfo)
     elif interval >= HOUR:
-        requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour)
+        requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour, tzinfo=tzinfo)
     elif interval >= MINUTE:
         requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour,
-                                               s.minute)
+                                               s.minute, tzinfo=tzinfo)
 
     for i, series in enumerate(seriesList):
         # XXX: breaks with summarize(metric.{a,b})
@@ -2738,6 +2740,9 @@ def smartSummarize(requestContext, seriesList, intervalString, func='sum'):
 
         # Populate buckets
         for timestamp, value in datapoints:
+            # ISSUE: Sometimes there is a missing timestamp in datapoints when running a smartSummary
+            if not timestamp:
+                continue
             bucketInterval = int((timestamp - series.start) / interval)
 
             if bucketInterval not in buckets:

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2742,7 +2742,8 @@ def smartSummarize(requestContext, seriesList, intervalString, func='sum'):
 
         # Populate buckets
         for timestamp, value in datapoints:
-            # ISSUE: Sometimes there is a missing timestamp in datapoints when running a smartSummary
+            # ISSUE: Sometimes there is a missing timestamp in datapoints when
+            #        running a smartSummary
             if not timestamp:
                 continue
             bucketInterval = int((timestamp - series.start) / interval)

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2711,8 +2711,7 @@ def smartSummarize(requestContext, seriesList, intervalString, func='sum'):
 
     # Adjust the start time to fit an entire day for intervals >= 1 day
     requestContext = requestContext.copy()
-    # ISSUE #51: Added tzinfo to requestContext in graphite_api/app.py:328
-    tzinfo = requestContext.get('tzinfo', None)
+    tzinfo = requestContext['tzinfo']
     s = requestContext['startTime']
     if interval >= DAY:
         requestContext['startTime'] = datetime(s.year, s.month, s.day,

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2715,9 +2715,11 @@ def smartSummarize(requestContext, seriesList, intervalString, func='sum'):
     tzinfo = requestContext.get('tzinfo', None)
     s = requestContext['startTime']
     if interval >= DAY:
-        requestContext['startTime'] = datetime(s.year, s.month, s.day, tzinfo=tzinfo)
+        requestContext['startTime'] = datetime(s.year, s.month, s.day,
+                                               tzinfo=tzinfo)
     elif interval >= HOUR:
-        requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour, tzinfo=tzinfo)
+        requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour,
+                                               tzinfo=tzinfo)
     elif interval >= MINUTE:
         requestContext['startTime'] = datetime(s.year, s.month, s.day, s.hour,
                                                s.minute, tzinfo=tzinfo)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -963,9 +963,12 @@ class FunctionsTest(TestCase):
         self.assertEqual(grep, [series[0]])
 
     def test_smart_summarize(self):
+        import pytz
+
         ctx = {
             'startTime': parseATTime('-1min'),
             'endTime': parseATTime('now'),
+            'tzinfo': pytz.timezone('UTC'),
         }
         series = self._generate_series_list(config=[range(100)])
         for s in series:
@@ -984,6 +987,9 @@ class FunctionsTest(TestCase):
 
         summ = functions.smartSummarize(ctx, series, '5s', 'min')[0]
         self.assertEqual(summ[:3], [42, 47, 52])
+
+        # Higher time interval should not trigger timezone errors
+        functions.smartSummarize(ctx, series, '100s', 'min')[0]
 
     def test_summarize(self):
         series = self._generate_series_list(config=[list(range(99)) + [None]])

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -985,8 +985,6 @@ class FunctionsTest(TestCase):
         self.assertEqual(grep, [series[0]])
 
     def test_smart_summarize(self):
-        import pytz
-
         ctx = {
             'startTime': parseATTime('-1min'),
             'endTime': parseATTime('now'),


### PR DESCRIPTION
Bruno,

Here are some changes which seem to correct the missing timezone behavior of the smartSummarize function.

I added the tzinfo as a value to the requestContext dictionary in app.py.
I used this tzinfo in functions.py to add tzinfo to the smartSummarize function.
I also noticed that some datapoints (usually the last one in my experience) are missing timestamp data in the smartSummarize function, so I added a quick check to ensure they are present.

This bug is discussed here:
https://github.com/brutasse/graphite-api/issues/51

I've tried to ensure that this patch passed tox testing.  Travis-CI testing still seems to fail based on DeprecatedWarning messages in the setuptools module.  I have patches to the tox.ini file if you are interested.

Thanks for your time and consideration!

--Geoff Thornton