### PR TITLE
Add 2 dependencies to debian packages

### DIFF
--- a/fpm/build-deb.sh
+++ b/fpm/build-deb.sh
@@ -33,6 +33,8 @@ fpm \
 	--config-files /etc/default/graphite-api \
 	-d libcairo2 \
 	-d "libffi5 | libffi6" \
+	-d adduser \
+	-d python \
 	--after-install conf/post-install \
 	--before-remove conf/pre-remove \
 	--after-remove conf/post-remove \


### PR DESCRIPTION
This prevents these 2 errors when installing in a stripped down debian/ubuntu environment:

```
Setting up graphite-api (1.0.1-exoscale1400326939) ...
/var/lib/dpkg/info/graphite-api.postinst: line 6: python: command not found
dpkg: error processing graphite-api (--install):
 subprocess installed post-installation script returned error exit status 127

Setting up graphite-api (1.0.1-exoscale1400326939) ...
/var/lib/dpkg/info/graphite-api.postinst: line 11: adduser: command not found
dpkg: error processing graphite-api (--configure):
 subprocess installed post-installation script returned error exit status 127
```