### PR TITLE
Fix ceres support requesting metrics

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -121,13 +121,18 @@ def metrics_find():
         errors['wildcards'] = 'must be 0 or 1.'
 
     try:
-        from_time = int(RequestParams.get('from', 0))
+        from_time = int(RequestParams.get('from', -1))
     except ValueError:
         errors['from'] = 'must be an epoch timestamp.'
     try:
-        until_time = int(RequestParams.get('until', 0))
+        until_time = int(RequestParams.get('until', -1))
     except ValueError:
         errors['until'] = 'must be an epoch timestamp.'
+
+    if from_time == -1:
+        from_time = None
+    if until_time == -1:
+        until_time = None
 
     format = RequestParams.get('format', 'treejson')
     if format not in ['treejson', 'completer']:


### PR DESCRIPTION
This is to correctly set fromTime/untilTime values as ``None``, because cere takes the value '0' to mean epoch zero.

Change cherry picked from upstream graphite-web:
https://github.com/graphite-project/graphite-web/commit/f18bb3c711bd566debf3edcc6b895be9fb6210b0#diff-2b06b3a96678041d3cc363a20371fb88L98