### PR TITLE
Now getting paths from all targets before fetching data.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .tox
 *.egg-info
+*.pyc
 .coverage
 htmlcov
 docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python: 3.4
+sudo: false
 
 env:
   - TOXENV=py26
@@ -14,8 +15,10 @@ env:
   - TOXENV=lint
   - TOXENV=docs
 
-before_install:
-  - sudo apt-get -y install libcairo2-dev
+addons:
+  apt:
+    packages:
+      - libcairo2-dev
 
 install:
   - pip install tox

--- a/graphite_api/render/datalib.py
+++ b/graphite_api/render/datalib.py
@@ -78,84 +78,108 @@ class TimeSeries(list):
             self.name, self.start, self.end, self.step)
 
 
-# Data retrieval API
-def fetchData(requestContext, pathExpr):
-    from ..app import app
+class DataStore(object):
+    """
+    Simple object to store results of multi fetches.
+    Also aids in looking up data by pathExpressions.
+    """
+    def __init__(self):
+        self.paths = defaultdict(list)
+        self.data = defaultdict(list)
 
-    seriesList = []
+    def add_path(self, path_expr, path):
+        """
+        Adds the path to the pathExpression.
+        """
+        # Only add if we dont already have the path
+        if path not in self.paths[path_expr]:
+            self.paths[path_expr].append(path)
+
+    def get_paths(self, path_expr):
+        """
+        Returns all paths found for path_expr
+        """
+        return self.paths[path_expr]
+
+    def add_data(self, path, time_info, data):
+        """
+        Stores data before it can be put into a time series
+        """
+        # Dont add if empty
+        if not nonempty(data):
+            for d in self.data[path]:
+                if nonempty(d['values']):
+                    return
+
+        # Add data to path
+        self.data[path].append({
+            'time_info': time_info,
+            'values': data
+        })
+
+    def get_series_list(self, path_expr):
+        series_list = []
+        for path in self.get_paths(path_expr):
+            for data in self.data.get(path):
+                start, end, step = data['time_info']
+                series = TimeSeries(path, start, end, step, data['values'])
+                series.pathExpression = path_expr
+                series_list.append(series)
+        return series_list
+
+
+def fetchData(requestContext, pathExprs):
+    from ..app import app
     startTime = int(epoch(requestContext['startTime']))
     endTime = int(epoch(requestContext['endTime']))
 
-    def _fetchData(pathExpr, startTime, endTime, requestContext, seriesList):
-        matching_nodes = app.store.find(pathExpr, startTime, endTime)
+    # Convert to list if given single path
+    if not isinstance(pathExprs, list):
+        pathExprs = [pathExprs]
 
-        # Group nodes that support multiple fetches
-        multi_nodes = defaultdict(list)
-        single_nodes = []
-        for node in matching_nodes:
+    data_store = DataStore()
+    multi_nodes = defaultdict(list)
+    single_nodes = []
+
+    # Group nodes that support multiple fetches
+    for pathExpr in pathExprs:
+        for node in app.store.find(pathExpr):
             if not node.is_leaf:
                 continue
+            data_store.add_path(pathExpr, node.path)
             if hasattr(node, '__fetch_multi__'):
                 multi_nodes[node.__fetch_multi__].append(node)
             else:
                 single_nodes.append(node)
 
-        fetches = [
-            (node, node.fetch(startTime, endTime)) for node in single_nodes]
+    # Multi fetches
+    for finder in app.store.finders:
+        if not hasattr(finder, '__fetch_multi__'):
+            continue
+        nodes = multi_nodes[finder.__fetch_multi__]
+        if not nodes:
+            continue
+        time_info, series = finder.fetch_multi(nodes, startTime, endTime)
+        for path, values in series.items():
+            data_store.add_data(path, time_info, values)
 
-        for finder in app.store.finders:
-            if not hasattr(finder, '__fetch_multi__'):
-                continue
-            nodes = multi_nodes[finder.__fetch_multi__]
-            if not nodes:
-                continue
-            time_info, series = finder.fetch_multi(nodes, startTime, endTime)
-            start, end, step = time_info
-            for path, values in series.items():
-                series = TimeSeries(path, start, end, step, values)
-                series.pathExpression = pathExpr
-                seriesList.append(series)
+    # Single fetches
+    fetches = [
+        (node, node.fetch(startTime, endTime)) for node in single_nodes]
+    for node, results in fetches:
+        if not results:
+            logger.info("no results", node=node, start=startTime,
+                        end=endTime)
+            continue
 
-        for node, results in fetches:
-            if not results:
-                logger.info("no results", node=node, start=startTime,
-                            end=endTime)
-                continue
+        try:
+            time_info, values = results
+        except ValueError as e:
+            raise Exception("could not parse timeInfo/values from metric "
+                            "'%s': %s" % (node.path, e))
+        data_store.add_data(node.path, time_info, values)
 
-            try:
-                timeInfo, values = results
-            except ValueError as e:
-                raise Exception("could not parse timeInfo/values from metric "
-                                "'%s': %s" % (node.path, e))
-            start, end, step = timeInfo
-
-            series = TimeSeries(node.path, start, end, step, values)
-            # hack to pass expressions through to render functions
-            series.pathExpression = pathExpr
-            seriesList.append(series)
-
-        # Prune empty series with duplicate metric paths to avoid showing
-        # empty graph elements for old whisper data
-        names = set([s.name for s in seriesList])
-        for name in names:
-            series_with_duplicate_names = [
-                s for s in seriesList if s.name == name]
-            empty_duplicates = [
-                s for s in series_with_duplicate_names
-                if not nonempty(series)]
-
-            if (
-                series_with_duplicate_names == empty_duplicates and
-                len(empty_duplicates) > 0
-            ):  # if they're all empty
-                empty_duplicates.pop()  # make sure we leave one in seriesList
-
-            for series in empty_duplicates:
-                seriesList.remove(series)
-
-        return seriesList
-
-    return _fetchData(pathExpr, startTime, endTime, requestContext, seriesList)
+    return data_store
 
 
 def nonempty(series):

--- a/graphite_api/render/datalib.py
+++ b/graphite_api/render/datalib.py
@@ -84,22 +84,20 @@ class DataStore(object):
     Also aids in looking up data by pathExpressions.
     """
     def __init__(self):
-        self.paths = defaultdict(list)
+        self.paths = defaultdict(set)
         self.data = defaultdict(list)
 
     def add_path(self, path_expr, path):
         """
         Adds the path to the pathExpression.
         """
-        # Only add if we dont already have the path
-        if path not in self.paths[path_expr]:
-            self.paths[path_expr].append(path)
+        self.paths[path_expr].add(path)
 
     def get_paths(self, path_expr):
         """
         Returns all paths found for path_expr
         """
-        return self.paths[path_expr]
+        return sorted(self.paths[path_expr])
 
     def add_data(self, path, time_info, data):
         """

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,71 @@
+from . import TestCase
+from graphite_api.app import pathsFromTarget
+
+
+class PathsTest(TestCase):
+    """
+    TestCase for pathsFromTarget function
+
+    """
+    def validate_paths(self, expected, test):
+        """
+        Assert the lengths of the expected list and the test list are the same
+        Also assert that every member of the expected list is present in the
+            test list.
+
+        """
+        # Check that test is a list
+        self.assertTrue(isinstance(test, list))
+        # Check length before converting to sets
+        self.assertEqual(len(expected), len(test))
+        # Convert lists to sets and verify equality
+        self.assertEqual(set(expected), set(test))
+
+    def test_simple(self):
+        """
+        Tests a target containing a single path expression.
+
+        """
+        target = 'test.simple.metric'
+        expected = [target]
+        self.validate_paths(expected, pathsFromTarget(target))
+
+    def test_func_args(self):
+        """
+        Tests a target containing function call with path expressions as
+        arguments.
+
+        """
+        path_1 = 'test.1.metric'
+        path_2 = 'test.2.metric'
+        target = 'sumSeries(%s,%s)' % (path_1, path_2)
+        expected = [path_1, path_2]
+        self.validate_paths(expected, pathsFromTarget(target))
+
+    def test_func_kwargs(self):
+        """
+        Tests a target containing a function call with path expressions as
+        a kwarg.
+
+        """
+        path_a = 'test.a.metric'
+        path_b = 'test.b.metric'
+        target = 'someFunc(%s,b=%s)' % (path_a, path_b)
+        expected = [path_a, path_b]
+        self.validate_paths(expected, pathsFromTarget(target))
+
+    def test_func_nested(self):
+        """
+        Tests a target containing nested functions with a mix of args and
+        kwargs.
+
+        """
+        paths = (
+            'test.a.metric',
+            'test.b.metric',
+            'test.c.metric',
+            'test.d.metric',
+        )
+        target = 'outerFunc(innerFunc(%s, %s), s=innerFunc(%s, %s))' % paths
+        expected = list(paths)
+        self.validate_paths(expected, pathsFromTarget(target))

--- a/tox.ini
+++ b/tox.ini
@@ -105,5 +105,6 @@ changedir = docs
 deps =
 	Sphinx
 	sphinx_rtd_theme
+	structlog
 commands =
 	sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
 	Flask-Cache
 	PyYAML
 	cairocffi
-	mock
 	pytz
 	raven[flask]
 	six
@@ -38,18 +37,21 @@ deps =
 	unittest2
 	logutils
 	ordereddict
+	mock<1.1.0
 
 [testenv:py27]
 deps =
 	{[testenv]deps}
 	Flask
 	pyparsing
+	mock
 
 [testenv:py33]
 deps =
 	{[testenv]deps}
 	Flask
 	pyparsing
+	mock
 
 [testenv:py34]
 commands =
@@ -58,6 +60,7 @@ deps =
 	{[testenv]deps}
 	Flask
 	pyparsing
+	mock
 
 [testenv:pyparsing1]
 basepython = python2.7
@@ -65,6 +68,7 @@ deps =
 	{[testenv]deps}
 	Flask
 	pyparsing==1.5.7
+	mock
 
 [testenv:pypy]
 basepython = pypy
@@ -72,6 +76,7 @@ deps =
 	{[testenv]deps}
 	Flask
 	pyparsing
+	mock
 
 [testenv:flask08]
 basepython = python2.7
@@ -79,6 +84,7 @@ deps =
 	{[testenv]deps}
 	Flask<0.9
 	pyparsing
+	mock
 
 [testenv:flask09]
 basepython = python2.7
@@ -86,6 +92,7 @@ deps =
 	{[testenv]deps}
 	Flask<0.10
 	pyparsing
+	mock
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Greetings,

I have been using the awesome graphite-api now for a few months. I have run into some scaling issues where I am sometimes looking at a composition of 80 metrics (40 targets, each a metric as a percent of another metric) at a time and wanted to take some steps in order to take more advantage of the 'fetch_multi' feature.

This pull request aims to find all paths and fetch all data before evaluating targets. The general process is to find paths from all targets, get all data for all paths into a single data store, then provide access to the data store to evaluateTarget. Functions in functions.py that alter the requestContext and re-fetch the data will not see any improvement as data is fetched when the target is evaluated.
