### PR TITLE
Fix calling reduceFunction in reduceSeries

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2825,7 +2825,7 @@ def reduceSeries(requestContext, seriesLists, reduceFunction, reduceNode,
                 metaSeries[reduceSeriesName][i] = series
     for key in keys:
         metaSeries[key] = app.functions[reduceFunction](requestContext,
-                                                        metaSeries[key])[0]
+                                                        *[[s] for s in metaSeries[key]])[0]
         metaSeries[key].name = key
     return [metaSeries[key] for key in keys]
 


### PR DESCRIPTION
Before it was only sending all the series as `args[1]`, however each series needs to be passed as an arg.
Use same way graphite-web see graphite-project/graphite-web#1265