### PR TITLE
Fix the GzippedWhisperReader

### DIFF
--- a/graphite_api/finders/whisper.py
+++ b/graphite_api/finders/whisper.py
@@ -133,7 +133,7 @@ class GzippedWhisperReader(WhisperReader):
     def get_intervals(self):
         fh = gzip.GzipFile(self.fs_path, 'rb')
         try:
-            info = whisper.__readHeader(fh)  # evil, but necessary.
+            info = getattr(whisper, '__readHeader')(fh)  # evil, but necessary.
         finally:
             fh.close()
 


### PR DESCRIPTION
The GzippedWhisperReader would attempt to use a private method in
python. Since methods starting with `__` are treated specially in python
by prepending `_$class` before attempting to invoke the method, this
code didn't work for accessing the private module method `__readHeader`
that exists in the whisper module.