### PR TITLE
Limit the results of the carbon query to only the current range

### DIFF
--- a/graphite_api/finders/whisper.py
+++ b/graphite_api/finders/whisper.py
@@ -122,6 +122,9 @@ class WhisperReader(object):
             if isinstance(cached_datapoints, dict):
                 cached_datapoints = cached_datapoints.items()
             for timestamp, value in sorted(cached_datapoints):
+                # filter only to cached datapoints within [start, end)
+                if not (timestamp >= start and timestamp < end):
+                    continue
                 interval = timestamp - (timestamp % step)
                 i = int(interval - start) // step
                 values[i] = value


### PR DESCRIPTION
The carbon query will return all cached datapoints. This includes values
that are outside of your current query. When the carbonlink attempts to
put these values in the returned array, an index error gets thrown. This
causes a lot of errors that get thrown when datapoints are cached and
the requested range does not match the timestamps of the cached
datapoints.

Teach the carbon query how to limit which metrics get inserted into the
cache based on their timestamps.