### PR TITLE
Add dependency to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'six',
     'structlog',
     'tzlocal',
+    'setuptools',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
While setuptools is obviously needed to run setup.py, it is also
mandatory at runtime to make entry points work as expected (through
pkg-resources).