### PR TITLE
Allow tests to succeed without Flask-Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - TOXENV=pyparsing1
   - TOXENV=flask08
   - TOXENV=flask09
+  - TOXENV=no-flask-cache
   - TOXENV=coverage
   - TOXENV=lint
   - TOXENV=docs

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -7,6 +7,11 @@ from graphite_api._vendor import whisper
 
 from . import TestCase, WHISPER_DIR
 
+try:
+    from flask.ext.cache import Cache
+except ImportError:
+    Cache = None
+
 
 class RenderTest(TestCase):
     db = os.path.join(WHISPER_DIR, 'test.wsp')
@@ -208,7 +213,7 @@ class RenderTest(TestCase):
             response = self.app.get(self.url, query_string=qs)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.headers['Content-Type'], 'image/png')
-            if qs.get('noCache'):
+            if Cache is None or qs.get('noCache'):
                 self.assertEqual(response.headers['Pragma'], 'no-cache')
                 self.assertEqual(response.headers['Cache-Control'], 'no-cache')
                 self.assertFalse('Expires' in response.headers)

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ setenv =
 commands =
 	python -Werror -m unittest discover
 deps =
-	Flask-Cache
 	PyYAML
 	cairocffi
 	pytz
@@ -35,6 +34,7 @@ commands =
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing
 	unittest2
 	logutils
@@ -46,6 +46,7 @@ basepython = python2.7
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing
 	mock
 
@@ -54,6 +55,7 @@ basepython = python3.3
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing
 
 [testenv:py34]
@@ -63,6 +65,7 @@ commands =
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing
 
 [testenv:py35]
@@ -72,6 +75,7 @@ commands =
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing
 
 [testenv:pyparsing1]
@@ -79,6 +83,7 @@ basepython = python2.7
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing==1.5.7
 	mock
 
@@ -87,6 +92,7 @@ basepython = pypy
 deps =
 	{[testenv]deps}
 	Flask
+	Flask-Cache
 	pyparsing
 	mock
 
@@ -95,6 +101,7 @@ basepython = python2.7
 deps =
 	{[testenv]deps}
 	Flask<0.9
+	Flask-Cache
 	pyparsing
 	mock
 
@@ -103,8 +110,18 @@ basepython = python2.7
 deps =
 	{[testenv]deps}
 	Flask<0.10
+	Flask-Cache
 	pyparsing
 	mock
+
+[testenv:no-flask-cache]
+basepython = python3.4
+commands =
+	python -Wall -m unittest discover
+deps =
+	{[testenv]deps}
+	Flask
+	pyparsing
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
When we are unable to import Flask-Cache, assume that cache is not
enabled.