### PR TITLE
Fix slowdown in rendering caused by #119

### DIFF
--- a/graphite_api/render/datalib.py
+++ b/graphite_api/render/datalib.py
@@ -140,7 +140,7 @@ def fetchData(requestContext, pathExprs):
 
     # Group nodes that support multiple fetches
     for pathExpr in pathExprs:
-        for node in app.store.find(pathExpr):
+        for node in app.store.find(pathExpr, startTime, endTime):
             if not node.is_leaf:
                 continue
             path_to_exprs[node.path].append(pathExpr)


### PR DESCRIPTION
As raised in #119 - after switching, I saw a big slow down on rendering, and an increase of CPU usage server-side.

This looks to be one of the main reasons for what I was seeing, where before only nodes with data in the request interval were returned.  I'm sure there are other performance regressions hidden in there somewhere though.  I'll have to make the switch back over and see if I can reproduce in production.  :-)