### PR TITLE
Fix regression in multi fetch handling

### DIFF
--- a/graphite_api/render/datalib.py
+++ b/graphite_api/render/datalib.py
@@ -159,7 +159,7 @@ def fetchData(requestContext, pathExprs):
         time_info, series = finder.fetch_multi(nodes, startTime, endTime)
         for path, values in series.items():
             data_store.add_data(path, time_info, values,
-                                path_to_exprs[node.path])
+                                path_to_exprs[path])
 
     # Single fetches
     fetches = [


### PR DESCRIPTION
Fixes a regression in multi-fetch introduced in this commit: https://github.com/brutasse/graphite-api/commit/90ba6d304917a533f682e46f5b369fc52a6dc62f