### PR TITLE
Fix series name in aggregateLine

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2592,10 +2592,11 @@ def aggregateLine(requestContext, seriesList, func='avg'):
     results = []
     for series in seriesList:
         value = t_funcs[func](series)
-        name = 'aggregateLine(%s,%d)' % (series.pathExpression, value)
+        name = 'aggregateLine(%s,"%s")' % (series.name, func)
 
         [series] = constantLine(requestContext, value)
         series.name = name
+        series.pathExpression = series.name
         results.append(series)
     return results
 


### PR DESCRIPTION
``aggregateLine`` is a strange one.

When calling with the following target: ``aggregateLine(foo-*.bar)``

It will return: ``aggregateLine(foo-*.bar, 42), aggregateLine(foo-*.bar, 45), ...``

In other words, it's impossible to distinguish between one metric and the other.

This change fixes that so the name+pathExpression are updated in the same way as other render functions do.  Change should be upstream-able too.