### PR TITLE
Fix maxDataPoints trimming rather than consolidating.

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -232,7 +232,7 @@ def prune_datapoints(series, max_datapoints, start, end):
         step = series.step
 
     timestamps = range(series.start, series.end + series.step, step)
-    datapoints = zip(series, timestamps)
+    datapoints = zip(iter(series), timestamps)
     return {'target': series.name, 'datapoints': datapoints}
 
 


### PR DESCRIPTION
Closes #151

Don't know why zip() doesn't call series.__iter__().
When debugging print didn't use series.__repr__() either.
Must be a pypy thing...