### PR TITLE
adding cache support for raw and json formats

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -435,7 +435,11 @@ def render():
                     series_data.append({'target': series.name,
                                         'datapoints': datapoints})
 
-            return jsonify(series_data, headers=headers)
+            response = jsonify(series_data, headers=headers)
+
+            if use_cache:
+                app.cache.add(request_key, response, cache_timeout)
+            return response
 
         if request_options['format'] == 'raw':
             response = StringIO()
@@ -446,6 +450,11 @@ def render():
                 response.write(u'\n')
             response.seek(0)
             headers['Content-Type'] = 'text/plain'
+            if use_cache:
+                app.cache.add(request_key,
+                              (response.read(), 200, headers),
+                              cache_timeout)
+            response.seek(0)
             return response.read(), 200, headers
 
         if request_options['format'] == 'svg':


### PR DESCRIPTION
Previously only render images would be cached. Adding support for pushing json and raw formatted data into cache as well. This lessens the load on the backend when interacting with a dashboards that redraws frequently, or multiple systems which are monitoring for only telemetry data points. 