### PR TITLE
aliasByNode() -> allowing colon(:) and hash(#) in node names

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -1334,7 +1334,7 @@ def aliasByNode(requestContext, seriesList, *nodes):
 
     """
     for series in seriesList:
-        metric_pieces = re.search('(?:.*\()?(?P<name>[-\w*\.]+)(?:,|\)?.*)?',
+        metric_pieces = re.search('(?:.*\()?(?P<name>[-\w*\.:#]+)(?:,|\)?.*)?',
                                   series.name).groups()[0].split('.')
         series.name = '.'.join(metric_pieces[n] for n in nodes)
     return seriesList


### PR DESCRIPTION
this fixes https://github.com/grafana/grafana/issues/1524
(it also adds the # as I'm using it in my metrics language)