### PR TITLE
leftover from aliasByMetric

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -1350,7 +1350,7 @@ def aliasByMetric(requestContext, seriesList):
 
     """
     for series in seriesList:
-        series.name = series.name.split('.')[-1].split(',')[0]
+        series.name = series.name.split('.')[-1].split(',')[0].strip(')')
     return seriesList
 
 


### PR DESCRIPTION
when applying this function on a metric that has scaling/manipulative function applies, it leaves behind a parenthesis... this is a small change to clean it up