### PR TITLE
glyph: Handle float equality errors in frange loop

### DIFF
--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -1997,9 +1997,13 @@ def closest(number, neighbors):
     return closestNeighbor
 
 
+def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
+    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
+
 def frange(start, end, step):
     f = start
-    while f <= end:
+    while f < end or isclose(f, end):
         yield f
         f += step
         # Protect against rounding errors on very small float ranges


### PR DESCRIPTION
Occasionally, I see that the top of graphs are chopped off, tracked this down to `frange` sometimes returning `False` on equality comparisons due to rounding errors.

Eg, this is wrong:
```
self.getYLabelValues(0, 7.2, 1.2)
=> [0, 1.2, 2.4, 3.5999999999999996, 4.8, 6.0]
```
Whereas the next step up returns correctly:
```
self.getYLabelValues(0, 8.4, 1.2)
=> [0, 1.2, 2.4, 3.5999999999999996, 4.8, 6.0, 7.2, 8.4]
```

Implementation comes from https://docs.python.org/3/whatsnew/3.5.html#pep-485-a-function-for-testing-approximate-equality