### PR TITLE
Cache json/csv/raw responses if needed

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -416,7 +416,10 @@ def render():
                                      ts.strftime("%Y-%m-%d %H:%M:%S"), value))
             response.seek(0)
             headers['Content-Type'] = 'text/csv'
-            return response.read(), 200, headers
+            response = (response.read(), 200, headers)
+            if use_cache:
+                app.cache.add(request_key, response, cache_timeout)
+            return response
 
         if request_options['format'] == 'json':
             series_data = []
@@ -435,7 +438,10 @@ def render():
                     series_data.append({'target': series.name,
                                         'datapoints': datapoints})
 
-            return jsonify(series_data, headers=headers)
+            response = jsonify(series_data, headers=headers)
+            if use_cache:
+                app.cache.add(request_key, response, cache_timeout)
+            return response
 
         if request_options['format'] == 'raw':
             response = StringIO()
@@ -446,7 +452,10 @@ def render():
                 response.write(u'\n')
             response.seek(0)
             headers['Content-Type'] = 'text/plain'
-            return response.read(), 200, headers
+            response = (response.read(), 200, headers)
+            if use_cache:
+                app.cache.add(request_key, response, cache_timeout)
+            return response
 
         if request_options['format'] == 'svg':
             graph_options['outputFormat'] = 'svg'

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -27,7 +27,8 @@ class RenderTest(TestCase):
 
     def test_render_view(self):
         response = self.app.get(self.url, query_string={'target': 'test',
-                                                        'format': 'json'})
+                                                        'format': 'json',
+                                                        'noCache': 'true'})
         self.assertEqual(json.loads(response.data.decode('utf-8')), [])
 
         response = self.app.get(self.url, query_string={'target': 'test'})


### PR DESCRIPTION
Previously, only PNG or SVG responses could be cached. Now JSON, CSV and raw responses are cached using the same logic.

Comparable to PR  #155 but a bit cleaner (I think).