### PR TITLE
Properly close <g> tag for certain SVG images

### DIFF
--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -693,12 +693,12 @@ class Graph(object):
                     for char in re.findall(r'L -(\d+) -\d+', match.group(1)):
                         name += chr(int(char))
                     return '</g><g data-header="true" class="%s">' % name
-                svgData, subs = re.subn(r'<path.+?d="M -88 -88 (.+?)"/>',
-                                        onHeaderPath, svgData)
+                (svgData, subsMade) = re.subn(r'<path.+?d="M -88 -88 (.+?)"/>', onHeaderPath, svgData)
 
-                # Hack to replace the first </g><g> with <g>
-                svgData = svgData.replace('</g><g data-header',
-                                          '<g data-header', 1)
+                # Hack to replace the first </g><g> with <g>, and close out the last </g> at the end
+                svgData = svgData.replace('</g><g data-header', '<g data-header', 1)
+                if subsMade > 0:
+                    svgData += "</g>"
                 svgData = svgData.replace(' data-header="true"', '')
 
             fileObj.write(svgData.encode())


### PR DESCRIPTION
It seems that 	commit bf130c28196486833b1029ae1abd96781d812363 in the merge from raintank/graphite-api#10 causes bad SVG output when the string replacement is actually performed.  This patch simply adds that support back using the current graphite-web code.