### PR TITLE
Backport groupByNodes() from graphite-web

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2880,6 +2880,45 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
     return [metaSeries[key] for key in keys]
 
 
+def groupByNodes(requestContext, seriesList, callback, *nodes):
+    """
+    Takes a serieslist and maps a callback to subgroups within as defined by
+    multiple nodes.
+
+    Example::
+
+        &target=groupByNodes(ganglia.server*.*.cpu.load*,"sumSeries",1,4)
+
+    Would return multiple series which are each the result of applying the
+    "sumSeries" function to groups joined on the nodes' list (0 indexed)
+    resulting in a list of targets like::
+
+        sumSeries(ganglia.server1.*.cpu.load5),
+        sumSeries(ganglia.server1.*.cpu.load10),
+        sumSeries(ganglia.server1.*.cpu.load15),
+        sumSeries(ganglia.server2.*.cpu.load5),
+        sumSeries(ganglia.server2.*.cpu.load10),
+        sumSeries(ganglia.server2.*.cpu.load15),...
+
+    """
+    from .app import app
+    metaSeries = {}
+    keys = []
+    for series in seriesList:
+        name_parts = series.name.split(".")
+        key = '.'.join(name_parts[n] for n in nodes)
+        if key not in metaSeries:
+            metaSeries[key] = [series]
+            keys.append(key)
+        else:
+            metaSeries[key].append(series)
+    for key in metaSeries.keys():
+        metaSeries[key] = app.functions[callback](requestContext,
+                                                  metaSeries[key])[0]
+        metaSeries[key].name = key
+    return [metaSeries[key] for key in keys]
+
+
 def exclude(requestContext, seriesList, pattern):
     """
     Takes a metric or a wildcard seriesList, followed by a regular expression

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2863,21 +2863,7 @@ def groupByNode(requestContext, seriesList, nodeNum, callback):
         sumSeries(ganglia.by-function.server2.*.cpu.load5),...
 
     """
-    from .app import app
-    metaSeries = {}
-    keys = []
-    for series in seriesList:
-        key = series.name.split(".")[nodeNum]
-        if key not in metaSeries:
-            metaSeries[key] = [series]
-            keys.append(key)
-        else:
-            metaSeries[key].append(series)
-    for key in metaSeries.keys():
-        metaSeries[key] = app.functions[callback](requestContext,
-                                                  metaSeries[key])[0]
-        metaSeries[key].name = key
-    return [metaSeries[key] for key in keys]
+    return groupByNodes(requestContext, seriesList, callback, nodeNum)
 
 
 def groupByNodes(requestContext, seriesList, callback, *nodes):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -999,6 +999,29 @@ class FunctionsTest(TestCase):
         self.assertEqual(grouped[0].name, 'test-db1')
         self.assertEqual(list(grouped[0])[:3], [100, 102, 104])
 
+    def test_group_by_nodes(self):
+        seriesList = [
+            TimeSeries('group1.server1.load5', 0, 2, 1, [10, 20]),
+            TimeSeries('group1.server1.load10', 0, 2, 1, [1, 2]),
+            TimeSeries('group1.server2.load5', 0, 2, 1, [30, 40]),
+            TimeSeries('group1.server2.load10', 0, 2, 1, [3, 4]),
+            TimeSeries('group2.server1.load5', 0, 2, 1, [40, 50]),
+            TimeSeries('group2.server1.load10', 0, 2, 1, [4, 5]),
+            TimeSeries('group2.server2.load5', 0, 2, 1, [60, 70]),
+            TimeSeries('group2.server2.load10', 0, 2, 1, [6, 7]),
+        ]
+        for series in seriesList:
+            series.pathExpression = series.name
+        grouped = functions.groupByNodes({}, seriesList,
+                                         'sumSeries', 0, 2)
+
+        expectedNames = ['group1.load5', 'group1.load10',
+                         'group2.load5', 'group2.load10']
+        self.assertEqual([s.name for s in grouped], expectedNames)
+
+        group1_load10 = grouped[1]
+        self.assertEqual(list(group1_load10), [4, 6])
+
     def test_exclude(self):
         series = self._generate_series_list(config=[range(100),
                                                     range(100, 200)])


### PR DESCRIPTION
Hello,

Yesterday graphite-web accepted a PR implementing `groupByNodes()` function. This patch backports it to graphite-api.

graphite-web PR: https://github.com/graphite-project/graphite-web/pull/1551