### PR TITLE
Increase coverage in graphite-api

### DIFF
--- a/graphite_api/carbonlink.py
+++ b/graphite_api/carbonlink.py
@@ -1,5 +1,4 @@
 import bisect
-import errno
 import random
 import socket
 import struct
@@ -8,7 +7,6 @@ import time
 from hashlib import md5
 from io import BytesIO
 from importlib import import_module
-from select import select
 
 import six
 from six.moves import cPickle as pickle  # noqa
@@ -287,24 +285,6 @@ class CarbonLinkRequestError(Exception):
 
 
 # Socket helper functions
-def still_connected(sock):
-    is_readable = select([sock], [], [], 0)[0]
-    if is_readable:
-        try:
-            recv_buf = sock.recv(1, socket.MSG_DONTWAIT | socket.MSG_PEEK)
-
-        except socket.error as e:
-            if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
-                return True
-            else:
-                raise
-        else:
-            return bool(recv_buf)
-
-    else:
-        return True
-
-
 def recv_exactly(conn, num_bytes):
     buf = b''
     while len(buf) < num_bytes:

--- a/graphite_api/readers.py
+++ b/graphite_api/readers.py
@@ -46,7 +46,7 @@ class MultiReader(object):
         t = start
         while t < end:
             # Look for the finer precision value first if available
-            i1 = (t - start1) / step1
+            i1 = (t - start1) // step1
 
             if len(values1) > i1:
                 v1 = values1[i1]
@@ -54,7 +54,7 @@ class MultiReader(object):
                 v1 = None
 
             if v1 is None:
-                i2 = (t - start2) / step2
+                i2 = (t - start2) // step2
 
                 if len(values2) > i2:
                     v2 = values2[i2]

--- a/tests/test_carbonlink.py
+++ b/tests/test_carbonlink.py
@@ -1,0 +1,182 @@
+import struct
+from six.moves import cPickle as pickle
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from graphite_api import carbonlink
+from graphite_api.carbonlink import ConsistentHashRing, CarbonLinkPool
+
+from . import TestCase
+
+
+class CarbonLinkTestCase(TestCase):
+    def test_allowed_modules(self):
+        with self.assertRaises(pickle.UnpicklingError) as context:
+            carbonlink.allowed_module('foo', 'bar')
+        self.assertIn('Attempting to unpickle unsafe module foo',
+                      str(context.exception))
+
+        with self.assertRaises(pickle.UnpicklingError) as context:
+            carbonlink.allowed_module('__builtin__', 'bar')
+        self.assertIn('Attempting to unpickle unsafe class bar',
+                      str(context.exception))
+
+        self.assertIsNotNone(carbonlink.allowed_module('collections', 'deque'))
+        self.assertIsNotNone(carbonlink.allowed_module('__builtin__', 'list'))
+
+
+class ConsistentHashRingTest(TestCase):
+    def test_chr_compute_ring_position(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'),
+                         64833)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'),
+                         38509)
+
+    def test_chr_add_node(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        self.assertEqual(hashring.nodes, set(hosts))
+        hashring.add_node(("127.0.0.1", "cache3"))
+        hosts.insert(0, ("127.0.0.1", "cache3"))
+        self.assertEqual(hashring.nodes, set(hosts))
+        self.assertEqual(hashring.nodes_len, 4)
+
+    def test_chr_add_node_duplicate(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        self.assertEqual(hashring.nodes, set(hosts))
+        hashring.add_node(("127.0.0.1", "cache2"))
+        self.assertEqual(hashring.nodes, set(hosts))
+        self.assertEqual(hashring.nodes_len, 3)
+
+    def test_chr_remove_node(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        self.assertEqual(hashring.nodes, set(hosts))
+        hashring.remove_node(("127.0.0.1", "cache2"))
+        hosts.pop()
+        self.assertEqual(hashring.nodes, set(hosts))
+        self.assertEqual(hashring.nodes_len, 2)
+
+    def test_chr_remove_node_missing(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        self.assertEqual(hashring.nodes, set(hosts))
+        hashring.remove_node(("127.0.0.1", "cache4"))
+        self.assertEqual(hashring.nodes, set(hosts))
+        self.assertEqual(hashring.nodes_len, 3)
+
+    def test_chr_get_node(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        node = hashring.get_node('hosts.worker1.cpu')
+        self.assertEqual(node, ('127.0.0.1', 'cache2'))
+
+    def test_chr_get_nodes(self):
+        hosts = [
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+            ("127.0.0.1", "cache2"),
+        ]
+        hashring = ConsistentHashRing(hosts)
+        node = hashring.get_nodes('hosts.worker1.cpu')
+        expected = [
+            ("127.0.0.1", "cache2"),
+            ("127.0.0.1", "cache0"),
+            ("127.0.0.1", "cache1"),
+        ]
+        self.assertEqual(node, expected)
+
+
+class CarbonLinkPoolTest(TestCase):
+    def test_clp_replication_factor(self):
+        with self.assertRaises(Exception) as context:
+            CarbonLinkPool(['127.0.0.1:2003'], replication_factor=2)
+        self.assertIn('replication_factor=2 cannot exceed servers=1',
+                      str(context.exception))
+
+    def test_clp_requests(self):
+        hosts = [
+            '192.168.0.1:2003:cache0',
+            '192.168.0.2:2003:cache1',
+            '192.168.0.3:2003:cache2',
+        ]
+        carbonlink = CarbonLinkPool(hosts, replication_factor=3)
+
+        with patch('socket.socket'):
+            for host in hosts:
+                server, port, instance = host.split(':')
+                conn = carbonlink.get_connection((server, instance))
+                conn.connect.assert_called_with((server, int(port)))
+                carbonlink.connections[(server, instance)].add(conn)
+
+        def mock_recv_query(size):
+            data = pickle.dumps(dict(datapoints=[1, 2, 3]))
+            if size == 4:
+                return struct.pack('!I', len(data))
+            elif size == len(data):
+                return data
+            else:
+                raise ValueError('unexpected size %s' % size)
+
+        conn.recv.side_effect = mock_recv_query
+        datapoints = carbonlink.query('hosts.worker1.cpu')
+        self.assertEqual(datapoints, [1, 2, 3])
+
+        datapoints = carbonlink.query('carbon.send_to_all.request')
+        self.assertEqual(datapoints, [1, 2, 3] * 3)
+
+        def mock_recv_get_metadata(size):
+            data = pickle.dumps(dict(value='foo'))
+            if size == 4:
+                return struct.pack('!I', len(data))
+            elif size == len(data):
+                return data
+            else:
+                raise ValueError('unexpected size %s' % size)
+
+        conn.recv.side_effect = mock_recv_get_metadata
+        metadata = carbonlink.get_metadata('hosts.worker1.cpu', 'key')
+        self.assertEqual(metadata, 'foo')
+
+        def mock_recv_set_metadata(size):
+            data = pickle.dumps(dict(old_value='foo', new_value='bar'))
+            if size == 4:
+                return struct.pack('!I', len(data))
+            elif size == len(data):
+                return data
+            else:
+                raise ValueError('unexpected size %s' % size)
+
+        conn.recv.side_effect = mock_recv_set_metadata
+        results = carbonlink.set_metadata('hosts.worker1.cpu', 'foo', 'bar')
+        self.assertEqual(results, {'old_value': 'foo', 'new_value': 'bar'})

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,0 +1,20 @@
+from graphite_api.encoders import JSONEncoder
+
+from . import TestCase
+
+
+class EncoderTestCase(TestCase):
+    def test_json_encoder(self):
+        encoder = JSONEncoder()
+
+        with self.assertRaises(TypeError):
+            encoder.default(object())
+
+        self.assertEqual(encoder.default(dict({1: 2})), {1: 2})
+        self.assertEqual(encoder.default(set([4, 5, 6])), [4, 5, 6])
+        self.assertEqual(encoder.default(DummyObject()), [7, 8, 9])
+
+
+class DummyObject(object):
+    def tolist(self):
+        return list([7, 8, 9])

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -24,6 +24,21 @@ class FinderTest(TestCase):
         self.assertEqual(time_info, (100, 200, 10))
         self.assertEqual(len(series), 10)
 
+    def test_multi_finder(self):
+        store = Store([DummyFinder(), DummyFinder()])
+        nodes = list(store.find("foo"))
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(nodes[0].path, 'foo')
+
+        nodes = list(store.find('bar.*'))
+        self.assertEqual(len(nodes), 10)
+        node = nodes[0]
+        self.assertEqual(node.path.split('.')[0], 'bar')
+
+        time_info, series = node.fetch(100, 200)
+        self.assertEqual(time_info, (100, 200, 10))
+        self.assertEqual(len(series), 10)
+
 
 class DummyReader(object):
     __slots__ = ('path',)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,22 @@
+import time
+
+from graphite_api.storage import FindQuery
+
+from . import TestCase
+
+
+class StorageTestCase(TestCase):
+    def test_find_query(self):
+        end = int(time.time())
+        start = end - 3600
+
+        query = FindQuery('collectd', None, None)
+        self.assertEqual(repr(query), '<FindQuery: collectd from * until *>')
+
+        query = FindQuery('collectd', start, None)
+        self.assertEqual(repr(query), '<FindQuery: collectd from %s until *>'
+                         % time.ctime(start))
+
+        query = FindQuery('collectd', None, end)
+        self.assertEqual(repr(query), '<FindQuery: collectd from * until %s>'
+                         % time.ctime(end))


### PR DESCRIPTION
Should increase coverage of all sources to above 70%, except `searcher.py`.

Found a Python 3 bug, and some dead code in the process.