### PR TITLE
Fix hitcount where align interval is >= 1d

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -3127,15 +3127,18 @@ def hitcount(requestContext, seriesList, intervalString,
 
     if alignToInterval:
         requestContext = requestContext.copy()
+        tzinfo = requestContext['tzinfo']
         s = requestContext['startTime']
         if interval >= DAY:
-            requestContext['startTime'] = datetime(s.year, s.month, s.day)
+            requestContext['startTime'] = datetime(s.year, s.month, s.day,
+                                                   tzinfo=tzinfo)
         elif interval >= HOUR:
             requestContext['startTime'] = datetime(s.year, s.month, s.day,
-                                                   s.hour)
+                                                   s.hour, tzinfo=tzinfo)
         elif interval >= MINUTE:
             requestContext['startTime'] = datetime(s.year, s.month, s.day,
-                                                   s.hour, s.minute)
+                                                   s.hour, s.minute,
+                                                   tzinfo=tzinfo)
 
         # Gather all paths first, then the data
         paths = []

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1052,6 +1052,7 @@ class FunctionsTest(TestCase):
         ctx = {
             'startTime': parseATTime('-1min'),
             'endTime': parseATTime('now'),
+            'tzinfo': pytz.timezone('UTC'),
         }
         series = self._generate_series_list(config=[list(range(99)) + [None]])
         for s in series:
@@ -1062,6 +1063,13 @@ class FunctionsTest(TestCase):
 
         hit = functions.hitcount(ctx, series, '5s', True)[0]
         self.assertEqual(hit[:3], [220, 245, 270])
+
+        try:
+            hit = functions.hitcount(ctx, series, '1min', True)[0]
+            hit = functions.hitcount(ctx, series, '1h', True)[0]
+            hit = functions.hitcount(ctx, series, '1d', True)[0]
+        except ValueError as e:
+            self.fail("hitcount() raised ValueError: %s" % str(e))
 
     def test_random_walk(self):
         ctx = {


### PR DESCRIPTION
Closes #171 

Like #172, but has regression tests, and uses same logic as `smartSummarize`.