### PR TITLE
Fix ValueError: math domain error in stdev

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -2205,9 +2205,11 @@ def stdev(requestContext, seriesList, points, windowTolerance=0.1):
                 validPoints > 0 and
                 float(validPoints) / points >= windowTolerance
             ):
-
-                deviation = math.sqrt(validPoints * currentSumOfSquares -
-                                      currentSum**2) / validPoints
+                try:
+                    deviation = math.sqrt(validPoints * currentSumOfSquares -
+                                          currentSum**2) / validPoints
+                except ValueError:
+                    deviation = None
                 stddevSeries.append(deviation)
             else:
                 stddevSeries.append(None)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1561,6 +1561,22 @@ class FunctionsTest(TestCase):
         dev = functions.stdev({}, series, 10)[0]
         self.assertEqual(dev[1], 0.5)
 
+    def test_stdev_math_domain(self):
+        # This data set is enough to trigger a math domain error in stdev.
+        # The last two data points should be NaN.
+        inputData = [0.9, 0.1, 0.5, 0.7, 0.5, 0.4, 0.4, 0.3, 0.6,
+                     0.6333333333333333, 1.3,
+                     0.6333333333333333, 0.6185185185185186,
+                     0.3, 0.5, 0.6, 0.3, 1.0, 0.6, 0.9, 0.4,
+                     0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        series = [
+            TimeSeries('collectd.test-db0.load.value', 600, 760, 5, inputData)
+        ]
+        series[0].pathExpression = series[0].name
+
+        result = functions.stdev({}, series, 10)[0]
+        self.assertEqual(result[-2:], [None, None])
+
     def test_holt_winters_analysis_none(self):
         seriesList = TimeSeries('collectd.test-db0.load.value',
                                 660, 700, 1, [None])


### PR DESCRIPTION
I thought this was a problem in graphite-web too, but infact it's not, and they catch `ValueError` as per this patch also.