### PR TITLE
Documentation fixes

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1139,14 +1139,14 @@ Determines how slice labels are rendered within a pie chart.
   Slice labels are reported as a percent of the whole
 
 valueLabelsColor
-----------------
+````````````````
 
 *Default: black*
 
 Color used to draw slice labels within a pie chart.
 
 valueLabelsMin
---------------
+``````````````
 
 *Default: 5*
 

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -27,7 +27,6 @@ import time
 
 from six.moves import zip_longest, map, reduce
 
-from .evaluator import evaluateTarget, evaluateTokens, pathsFromTarget
 from .render.attime import parseTimeOffset, parseATTime
 from .render.glyph import format_units
 from .render.datalib import TimeSeries, fetchData
@@ -3777,3 +3776,4 @@ SeriesFunctions = {
 }
 
 from .app import app  # noqa
+from .evaluator import evaluateTarget, evaluateTokens, pathsFromTarget  # noqa

--- a/tox.ini
+++ b/tox.ini
@@ -137,4 +137,4 @@ deps =
 	sphinx_rtd_theme
 	structlog
 commands =
-	sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+	sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
Noticed a couple of errors when building the docs for graphite-api.  A couple were introduced by recent changes.  And lastly had to turn off warnings as errors.