### PR TITLE
Don't use structlog versions newer than 16.0.0 for python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ install_requires = [
     'pyparsing>=1.5.7',
     'pytz',
     'six',
-    'structlog',
     'tzlocal',
 ]
 
@@ -18,6 +17,9 @@ if sys.version_info < (2, 7):
     install_requires.append('importlib')
     install_requires.append('logutils')
     install_requires.append('ordereddict')
+    install_requires.append('structlog<=16.0.0')
+else:
+    install_requires.append('structlog')
 
 with open('README.rst') as f:
     long_description = f.read()


### PR DESCRIPTION
Got round to looking at what changed to make the Python 2.6 builds fail - if it's still considered important to support this version, of course. :-)