### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Documentation
 
 `On readthedocs.org`_ or in the ``docs/`` directory.
 
-.. _On readthedocs.org: http://graphite-api.readthedocs.io/en/latest/
+.. _On readthedocs.org: https://graphite-api.readthedocs.io/en/latest/
 
 Hacking
 -------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.