### PR TITLE
[Ready for Review] - Make Cairo an optional dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,15 @@ Documentation
 
 .. _On readthedocs.org: https://graphite-api.readthedocs.io/en/latest/
 
+CairoCFFI dependency
+---------------------
+
+Cairo is intentionally disabled on Windows platforms. It may be enabled by using the ``cairo`` extras tag on install - ``pip install graphite-api[cairo]``.
+
+Cairo is not a hard requirement and it and its dependencies can be removed post-installation, though it will still be pulled in by pip by default on non-Windows platforms.
+
+If Cairo is not available Graphite-API will only support Json or raw output formats.
+
 Hacking
 -------
 

--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -17,9 +17,10 @@ from .config import configure
 from .encoders import JSONEncoder
 from .render.attime import parseATTime
 from .render.datalib import fetchData
+from .render.glyph import GraphTypes
 try:
-    from .render.glyph import GraphTypes
-except NameError:
+    import cairocffi as cairo
+except (NameError, ImportError, AttributeError):
     CAIRO_DISABLED=True
 else:
     CAIRO_DISABLED=False
@@ -260,15 +261,18 @@ def render():
 
     # Fill in the request_options
     graph_type = RequestParams.get('graphType', 'line')
+    request_options['graphType'] = graph_type
     if not CAIRO_DISABLED:
         try:
             graph_class = GraphTypes[graph_type]
-            request_options['graphType'] = graph_type
-            request_options['graphClass'] = graph_class
         except KeyError:
             errors['graphType'] = (
                 "Invalid graphType '{0}', must be one of '{1}'.".format(
                     graph_type, "', '".join(sorted(GraphTypes.keys()))))
+        else:
+            request_options['graphClass'] = graph_class
+    else:
+        request_options['graphClass'] = None
     request_options['pieMode'] = RequestParams.get('pieMode', 'average')
     targets = RequestParams.getlist('target')
     if not len(targets):

--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -17,13 +17,7 @@ from .config import configure
 from .encoders import JSONEncoder
 from .render.attime import parseATTime
 from .render.datalib import fetchData
-from .render.glyph import GraphTypes
-try:
-    import cairocffi as cairo
-except (NameError, ImportError, AttributeError):
-    CAIRO_DISABLED=True
-else:
-    CAIRO_DISABLED=False
+from .render.glyph import GraphTypes, CAIRO_DISABLED
 from .utils import RequestParams, hash_request
 
 logger = get_logger()
@@ -505,7 +499,8 @@ def render():
             return response
 
         if CAIRO_DISABLED:
-            errors = {'format': 'Requested image or pdf format but cairo library is not available'}
+            errors = {'format': 'Requested image or pdf format but cairo '
+                      'library is not available'}
             return jsonify({'errors': errors}, status=400)
         if request_options['format'] == 'svg':
             graph_options['outputFormat'] = 'svg'

--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -504,6 +504,9 @@ def render():
                 app.cache.add(request_key, response, cache_timeout)
             return response
 
+        if CAIRO_DISABLED:
+            errors = {'format': 'Requested image or pdf format but cairo library is not available'}
+            return jsonify({'errors': errors}, status=400)
         if request_options['format'] == 'svg':
             graph_options['outputFormat'] = 'svg'
         elif request_options['format'] == 'pdf':

--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -589,8 +589,6 @@ def tree_json(nodes, base_path, wildcards=False):
 
 
 def doImageRender(graphClass, graphOptions):
-    if not cairo:
-        return
     pngData = BytesIO()
     img = graphClass(**graphOptions)
     img.output(pngData)

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -28,7 +28,12 @@ import time
 from six.moves import zip_longest, map, reduce
 
 from .render.attime import parseTimeOffset, parseATTime
-from .render.glyph import format_units
+try:
+    from .render.glyph import format_units
+except NameError:
+    CAIRO_DISABLED=True
+else:
+    CAIRO_DISABLED=False
 from .render.datalib import TimeSeries, fetchData
 from .utils import to_seconds, epoch
 

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -28,12 +28,7 @@ import time
 from six.moves import zip_longest, map, reduce
 
 from .render.attime import parseTimeOffset, parseATTime
-try:
-    from .render.glyph import format_units
-except NameError:
-    CAIRO_DISABLED=True
-else:
-    CAIRO_DISABLED=False
+from .render.glyph import format_units
 from .render.datalib import TimeSeries, fetchData
 from .utils import to_seconds, epoch
 

--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -15,9 +15,9 @@ limitations under the License."""
 try:
     import cairocffi as cairo
 except (NameError, ImportError, AttributeError):
-    CAIRO_DISABLED=True
+    CAIRO_DISABLED = True
 else:
-    CAIRO_DISABLED=False
+    CAIRO_DISABLED = False
 import itertools
 import json
 import math
@@ -1394,7 +1394,6 @@ class LineGraph(Graph):
 
     def drawLines(self, width=None, dash=None, linecap='butt',
                   linejoin='miter'):
-        
         if not width:
             width = self.lineWidth
         self.ctx.set_line_width(width)

--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -14,10 +14,8 @@ limitations under the License."""
 
 try:
     import cairocffi as cairo
-except (NameError, ImportError, AttributeError):
-    CAIRO_DISABLED = True
-else:
-    CAIRO_DISABLED = False
+except (ImportError, AttributeError):
+    cairo = None
 import itertools
 import json
 import math
@@ -761,7 +759,7 @@ class Graph(object):
         self.drawGraph(**params)
 
     def setupCairo(self, outputFormat='png'):
-        if CAIRO_DISABLED:
+        if not cairo:
             return
         self.outputFormat = outputFormat
         if outputFormat == 'png':

--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -12,7 +12,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License."""
 
-import cairocffi as cairo
+try:
+    import cairocffi as cairo
+except NameError:
+    pass
+except AttributeError:
+    pass
 import itertools
 import json
 import math

--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -14,10 +14,10 @@ limitations under the License."""
 
 try:
     import cairocffi as cairo
-except NameError:
-    pass
-except AttributeError:
-    pass
+except (NameError, ImportError, AttributeError):
+    CAIRO_DISABLED=True
+else:
+    CAIRO_DISABLED=False
 import itertools
 import json
 import math
@@ -761,6 +761,8 @@ class Graph(object):
         self.drawGraph(**params)
 
     def setupCairo(self, outputFormat='png'):
+        if CAIRO_DISABLED:
+            return
         self.outputFormat = outputFormat
         if outputFormat == 'png':
             self.surface = cairo.ImageSurface(cairo.FORMAT_ARGB32,
@@ -1392,6 +1394,7 @@ class LineGraph(Graph):
 
     def drawLines(self, width=None, dash=None, linecap='butt',
                   linejoin='miter'):
+        
         if not width:
             width = self.lineWidth
         self.ctx.set_line_width(width)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 Flask-Cache
+cairocffi
 pyparsing>=1.5.7
 pytz
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask
 Flask-Cache
-cairocffi
 pyparsing>=1.5.7
 pytz
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
         'cyanite': ['cyanite'],
         'cache': ['Flask-Cache'],
         'statsd': ['statsd'],
-        ':sys_platform!="win32"': ['cairocffi'],
+        ':sys_platform!="win32" and ' \
+        'platform_python_implementation!="PyPy"': ['cairocffi'],
         'cairo': ['cairocffi'],
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from setuptools import setup, find_packages
 install_requires = [
     'Flask',
     'PyYAML',
-    'cairocffi',
     'pyparsing>=1.5.7',
     'pytz',
     'six',
@@ -44,6 +43,7 @@ setup(
         'cyanite': ['cyanite'],
         'cache': ['Flask-Cache'],
         'statsd': ['statsd'],
+        'cairo': ['cairocffi'],
     },
     zip_safe=False,
     platforms='any',

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'cyanite': ['cyanite'],
         'cache': ['Flask-Cache'],
         'statsd': ['statsd'],
+        ':sys_platform!="win32"': ['cairocffi'],
         'cairo': ['cairocffi'],
     },
     zip_safe=False,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -58,6 +58,9 @@ class TestCase(unittest.TestCase):
         whisper_conf = {'whisper': {'directories': [WHISPER_DIR]}}
         app.config['GRAPHITE']['store'] = Store([WhisperFinder(whisper_conf)])
         self.app = app.test_client()
+        self.cairo_missing_resp = {'errors': {
+            'format': 'Requested image or pdf format but cairo library '
+            'is not available'}}
 
     def tearDown(self):
         self._cleanup()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -26,8 +26,8 @@ class HttpTestCase(TestCase):
             'Access-Control-Allow-Origin' in response.headers.keys())
 
     def test_trailing_slash(self):
-        response = self.app.get('/render?target=foo')
+        response = self.app.get('/render?target=foo&format=json')
         self.assertEqual(response.status_code, 200)
 
-        response = self.app.get('/render/?target=foo')
+        response = self.app.get('/render/?target=foo&format=json')
         self.assertEqual(response.status_code, 200)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -41,7 +41,8 @@ class RenderTest(TestCase):
         response = self.app.get(self.url, query_string={'target': 'test',
                                                         'format': 'pdf'})
         if CAIRO_ENABLED:
-            self.assertEqual(response.headers['Content-Type'], 'application/x-pdf')
+            self.assertEqual(response.headers['Content-Type'],
+                             'application/x-pdf')
         else:
             self.assertJSON(response, self.cairo_missing_resp, status_code=400)
 
@@ -149,7 +150,7 @@ class RenderTest(TestCase):
         response = self.app.get(self.url, query_string={
             'target': 'constantLine(12)'})
         expected_content_type = 'image/png' if CAIRO_ENABLED \
-          else 'application/json'
+            else 'application/json'
         self.assertEqual(response.headers['Content-Type'],
                          expected_content_type)
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
 	python -Werror -m unittest discover
 deps =
 	PyYAML
-	cairocffi
+	setuptools>=28.0
 	pytz
 	raven[flask]
 	six
@@ -43,6 +43,7 @@ deps =
 	ordereddict
 	mock
 	scandir
+	cairocffi
 
 [testenv:py27]
 basepython = python2.7
@@ -53,6 +54,7 @@ deps =
 	pyparsing
 	mock
 	scandir
+	cairocffi
 
 [testenv:py33]
 basepython = python3.3
@@ -62,6 +64,7 @@ deps =
 	Flask-Cache
 	pyparsing
 	scandir
+	cairocffi
 
 [testenv:py34]
 basepython = python3.4
@@ -73,6 +76,7 @@ deps =
 	Flask-Cache
 	pyparsing
 	scandir
+	cairocffi
 
 [testenv:py35]
 basepython = python3.5
@@ -83,6 +87,7 @@ deps =
 	Flask
 	Flask-Cache
 	pyparsing
+	cairocffi
 
 [testenv:pyparsing1]
 basepython = python2.7
@@ -92,6 +97,7 @@ deps =
 	Flask-Cache
 	pyparsing==1.5.7
 	mock
+	cairocffi
 
 [testenv:pypy]
 basepython = pypy
@@ -110,6 +116,7 @@ deps =
 	Flask-Cache
 	pyparsing
 	mock
+	cairocffi
 
 [testenv:flask09]
 basepython = python2.7
@@ -119,6 +126,7 @@ deps =
 	Flask-Cache
 	pyparsing
 	mock
+	cairocffi
 
 [testenv:no-flask-cache]
 basepython = python3.5
@@ -128,12 +136,10 @@ deps =
 	{[testenv]deps}
 	Flask
 	pyparsing
+	cairocffi
 
 [testenv:no-cairo]
 basepython = python2.7
-commands =
-	pip install cairocffi
-	pip uninstall cairocffi -y
 	python -Wall -m unittest discover
 deps =
 	{[testenv]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -149,6 +149,7 @@ deps =
 [testenv:lint]
 deps =
 	flake8
+	setuptools>=28.0
 commands =
 	flake8 {toxinidir}/graphite_api {toxinidir}/tests
 
@@ -158,5 +159,6 @@ deps =
 	Sphinx
 	sphinx_rtd_theme
 	structlog
+	setuptools>=28.0
 commands =
 	sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html

--- a/tox.ini
+++ b/tox.ini
@@ -101,6 +101,8 @@ deps =
 
 [testenv:pypy]
 basepython = pypy
+commands =
+	pip uninstall -y cffi
 deps =
 	{[testenv]deps}
 	Flask

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
 	flask08,
 	flask09,
 	no-flask-cache,
+	no-cairo,
 	lint,
 	docs
 
@@ -127,6 +128,17 @@ deps =
 	{[testenv]deps}
 	Flask
 	pyparsing
+
+[testenv:no-cairo]
+basepython = python2.7
+commands =
+	pip install cairocffi
+	pip uninstall cairocffi -y
+	python -Wall -m unittest discover
+deps =
+	{[testenv]deps}
+	pyparsing
+	mock
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
Ready for review.

Changes:
* Cairocffi is *not* pulled in as dependency on Windows _and_ PyPy interpreters via setuptools `extras_requires` environment markers - requires setuptools >= `28.0`
* Without cairo, image/pdf format requests will return 400 error with message that cairo is not installed
* Added tox target for sans-cairo testing of expected 400 error code responses
* Removed cairocffi from tox global dependencies, added to individual env where applicable
* Added setuptools version requirement to tox dependencies
* Added uninstall step for PyPy's `cffi` package which is not compatible with graphite-api. Allows pypy tests to pass sans use of cairo
* Updated readme with note on cairo dependency being optional

To-do:
- [x] Add test target sans cairo
- [x] Add expected `400` error response tests for when cairo is not installed but request is asking for image/pdf formats
- [x] Update readme for `[cairo]` extras parameter on Windows

Comments, suggestions, feedback most welcome.

Resolves #149 
