### PR TITLE
glyph: Use explicit None comparison in getExtents

### DIFF
--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -808,7 +808,7 @@ class Graph(object):
     def getExtents(self, text=None):
         F = self.ctx.font_extents()
         extents = {'maxHeight': F[2], 'maxAscent': F[0], 'maxDescent': F[1]}
-        if text:
+        if text is not None:
             T = self.ctx.text_extents(text)
             extents['width'] = T[4]
             extents['height'] = T[3]

--- a/tests/test_render_glyph.py
+++ b/tests/test_render_glyph.py
@@ -92,6 +92,11 @@ class glyphStandaloneFunctionTest(TestCase):
     def test_safeMin_list_with_nan(self):
         self.assertEqual(glyph.safeMin([1, 5.1, 6, float('Nan')]), 1)
 
+    # Testing getExtents()
+    def test_getExtents_empty_string(self):
+        extents = glyph.Graph(data=[]).getExtents('')
+        self.assertEqual(extents['width'], 0)
+
     # Testing safeMax()
     def test_safeMax_None(self):
         with self.assertRaises(TypeError):

--- a/tests/test_render_glyph.py
+++ b/tests/test_render_glyph.py
@@ -94,8 +94,8 @@ class glyphStandaloneFunctionTest(TestCase):
 
     # Testing getExtents()
     def test_getExtents_empty_string(self):
-        extents = glyph.Graph(data=[]).getExtents('')
-        self.assertEqual(extents['width'], 0)
+        extents = glyph.LineGraph(data=[]).getExtents('')
+        self.assertEqual(extents['width'], 0.0)
 
     # Testing safeMax()
     def test_safeMax_None(self):


### PR DESCRIPTION
Consistently seeing incorrect behaviour/crashing on the `/render` endpoint
due to the changed line seemingly doing the wrong thing.

(Sorry if my regression test is in the wrong place)

Do a more explicit comparison to ensure the correct thing is being
checked, or else I get the following exception:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python2.7/site-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/python2.7/site-packages/graphite_api/app.py", line 455, in render
    image = doImageRender(request_options['graphClass'], graph_options)
  File "/usr/lib/python2.7/site-packages/graphite_api/app.py", line 591, in doImageRender
    img = graphClass(**graphOptions)
  File "/usr/lib/python2.7/site-packages/graphite_api/render/glyph.py", line 383, in __init__
    self.drawGraph(**params)
  File "/usr/lib/python2.7/site-packages/graphite_api/render/glyph.py", line 915, in drawGraph
    self.drawLabels()
  File "/usr/lib/python2.7/site-packages/graphite_api/render/glyph.py", line 1762, in drawLabels
    self.drawText(label, x, y, align='center', valign='top')
  File "/usr/lib/python2.7/site-packages/graphite_api/render/glyph.py", line 452, in drawText
    'center': extents['width'] / 2,
KeyError: 'width'
```