### PR TITLE
Allow empty finders configuration

### DIFF
--- a/graphite_api/config.py
+++ b/graphite_api/config.py
@@ -136,7 +136,7 @@ def configure(app):
     loaded_config['carbon'] = config.get('carbon', None)
 
     finders = []
-    for finder in config['finders']:
+    for finder in [f for f in config['finders'] if f]:
         finders.append(load_by_path(finder)(config))
     loaded_config['store'] = Store(finders)
     app.config['GRAPHITE'] = loaded_config

--- a/tests/no_finders_conf.yaml
+++ b/tests/no_finders_conf.yaml
@@ -1,0 +1,21 @@
+time_zone: UTC
+allowed_origins:
+  - example.com
+  - foo.example.com:8888
+cache:
+  type: simple
+  default_timeout: 0
+logging:
+  version: 1
+  disable_existing_loggers: true
+  handlers:
+    stdout:
+      class: logging.StreamHandler
+  loggers:
+    graphite_api:
+      handlers:
+        - stdout
+      propagate: true
+      level: INFO
+finders:
+  - 

--- a/tests/test_config_no_finders.py
+++ b/tests/test_config_no_finders.py
@@ -7,6 +7,7 @@ os.environ['GRAPHITE_API_CONFIG'] = os.path.join(
 from graphite_api.app import app
 from graphite_api.config import configure
 
+
 class NoFindersTest(unittest.TestCase):
 
     def test_app_no_finders(self):

--- a/tests/test_config_no_finders.py
+++ b/tests/test_config_no_finders.py
@@ -1,0 +1,14 @@
+import os
+import unittest
+
+os.environ['GRAPHITE_API_CONFIG'] = os.path.join(
+    os.path.dirname(__file__), 'no_finders_conf.yaml')  # noqa
+
+from graphite_api.app import app
+from graphite_api.config import configure
+
+class NoFindersTest(unittest.TestCase):
+
+    def test_app_no_finders(self):
+        configure(app)
+        self.assertTrue(app is not None)


### PR DESCRIPTION
In order to allow graphite-api to be used without any local finders, for example to use only remote carbon hosts, have made changes to allow for an empty finders configuration:

```
finders:
  -
```

Empty configuration is required as finders configuration defaults to whisper.

See #212 and #207 