### PR TITLE
Allow escaped and unescaped single and double quotes in metric names.

### DIFF
--- a/graphite_api/render/grammar.py
+++ b/graphite_api/render/grammar.py
@@ -60,7 +60,8 @@ comma = Literal(',').suppress()
 equal = Literal('=').suppress()
 backslash = Literal('\\').suppress()
 
-symbols = '''(){},=.'"\\'''
+unallowedSymbols = '''(){},=.\\'''
+allowedSymbols = ''''"'''
 arg = Group(
     boolean |
     number |
@@ -83,8 +84,8 @@ call = Group(
 )('call')
 
 # Metric pattern (aka. pathExpression)
-validMetricChars = ''.join((set(printables) - set(symbols)))
-escapedChar = backslash + Word(symbols, exact=1)
+validMetricChars = ''.join((set(printables) - set(unallowedSymbols)))
+escapedChar = backslash + Word(unallowedSymbols + allowedSymbols, exact=1)
 partialPathElem = Combine(
     OneOrMore(
         escapedChar | Word(validMetricChars)


### PR DESCRIPTION
This change would allow single and double quotes both escaped and unescaped in metric targets, with the goal of more closely matching the behavior of graphite-web, which allows both. 

Not attached to the formulation of the below, just interested in the end results. I am using (and loving) graphite-api as a (much simpler!) graphite-web and this is the first notable discrepancy reported by our users.