### PR TITLE
Sync graphite-api with upstream graphite-web 1.0.1

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -81,6 +81,13 @@ Extra sections
     consistent hashing and a custom function, you need to point to the same
     hashing function.
 
+  *hashing_type*
+    Type of metric hashing function. The default ``carbon_ch`` is Graphite's
+    traditional consistent-hashing implementation. Alternatively, you can use
+    ``fnv1a_ch``, which supports the Fowler-Noll-Vo hash function (FNV-1a) hash
+    implementation offered by the carbon-c-relay project.
+    Default: ``carbon_ch``
+
   *carbon_prefix*
     Prefix for carbon's internal metrics. When querying metrics starting with
     this prefix, requests are made to all carbon-cache instances instead of

--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -317,8 +317,9 @@ def render():
     request_options['tzinfo'] = tzinfo
 
     # Get the time interval for time-oriented graph types
-    until_time = parseATTime(RequestParams.get('until', 'now'), tzinfo)
-    from_time = parseATTime(RequestParams.get('from', '-1d'), tzinfo)
+    now = parseATTime(RequestParams.get('now', 'now'), tzinfo)
+    until_time = parseATTime(RequestParams.get('until', 'now'), tzinfo, now)
+    from_time = parseATTime(RequestParams.get('from', '-1d'), tzinfo, now)
 
     start_time = min(from_time, until_time)
     end_time = max(from_time, until_time)
@@ -327,6 +328,7 @@ def render():
 
     request_options['startTime'] = start_time
     request_options['endTime'] = end_time
+    request_options['now'] = now
 
     template = dict()
     for key in RequestParams.keys():
@@ -362,6 +364,7 @@ def render():
     context = {
         'startTime': request_options['startTime'],
         'endTime': request_options['endTime'],
+        'now': request_options['now'],
         'tzinfo': request_options['tzinfo'],
         'template': request_options['template'],
         'data': [],

--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -116,7 +116,7 @@ def metrics_find():
         until_time = None
 
     format = RequestParams.get('format', 'treejson')
-    if format not in ['treejson', 'completer', 'nodelist']:
+    if format not in ['treejson', 'completer', 'nodelist', 'json']:
         errors['format'] = 'unrecognized format: "{0}".'.format(format)
 
     if 'query' not in RequestParams:
@@ -146,6 +146,9 @@ def metrics_find():
             nodes = metric.path.split('.')
             found.add(nodes[node_position])
         return jsonify({'nodes': sorted(found)})
+    elif format == 'json':
+        content = json_nodes(matches)
+        return jsonify(content)
 
     results = []
     for node in matches:
@@ -578,6 +581,25 @@ def tree_json(nodes, base_path, wildcards=False):
     results.extend(results_branch)
     results.extend(results_leaf)
     return results
+
+
+def json_nodes(nodes):
+    nodes_info = []
+
+    for node in nodes:
+        info = {
+            'path': node.path,
+            'is_leaf': node.is_leaf,
+            'intervals': [],
+        }
+        if node.is_leaf:
+            for i in node.intervals:
+                interval = {'start': i.start, 'end': i.end}
+                info['intervals'].append(interval)
+
+        nodes_info.append(info)
+
+    return sorted(nodes_info, key=lambda item: item['path'])
 
 
 def doImageRender(graphClass, graphOptions):

--- a/graphite_api/finders/__init__.py
+++ b/graphite_api/finders/__init__.py
@@ -1,14 +1,18 @@
 import fnmatch
 import os.path
+import re
+
+EXPAND_BRACES_RE = re.compile(r'.*(\{.*?[^\\]?\})')
 
 
 def get_real_metric_path(absolute_path, metric_path):
     # Support symbolic links (real_metric_path ensures proper cache queries)
-    if os.path.islink(absolute_path):
-        real_fs_path = os.path.realpath(absolute_path)
+    real_fs_path = os.path.realpath(absolute_path)
+    if absolute_path != real_fs_path:
         relative_fs_path = metric_path.replace('.', os.sep)
-        base_fs_path = absolute_path[:-len(relative_fs_path)]
-        relative_real_fs_path = real_fs_path[len(base_fs_path):]
+        abs_fs_path = os.path.dirname(absolute_path[:-len(relative_fs_path)])
+        base_fs_path = os.path.realpath(abs_fs_path)
+        relative_real_fs_path = real_fs_path[len(base_fs_path):].lstrip('/')
         return fs_to_metric(relative_real_fs_path)
 
     return metric_path
@@ -42,20 +46,42 @@ def extract_variants(pattern):
 def match_entries(entries, pattern):
     """A drop-in replacement for fnmatch.filter that supports pattern
     variants (ie. {foo,bar}baz = foobaz or barbaz)."""
-    v1, v2 = pattern.find('{'), pattern.find('}')
+    matching = []
 
-    if v1 > -1 and v2 > v1:
-        variations = pattern[v1+1:v2].split(',')
-        variants = [pattern[:v1] + v + pattern[v2+1:] for v in variations]
-        matching = []
+    for variant in expand_braces(pattern):
+        matching.extend(fnmatch.filter(entries, variant))
 
-        for variant in variants:
-            matching.extend(fnmatch.filter(entries, variant))
+    return list(_deduplicate(matching))
 
-        # remove dupes without changing order
-        return list(_deduplicate(matching))
 
+def expand_braces(pattern):
+    """Find the rightmost, innermost set of braces and, if it contains a
+    comma-separated list, expand its contents recursively (any of its items
+    may itself be a list enclosed in braces).
+
+    Return the full list of expanded strings.
+    """
+    res = set()
+
+    # Used instead of s.strip('{}') because strip is greedy.
+    # We want to remove only ONE leading { and ONE trailing }, if both exist
+    def remove_outer_braces(s):
+        if s[0] == '{' and s[-1] == '}':
+            return s[1:-1]
+        return s
+
+    match = EXPAND_BRACES_RE.search(pattern)
+    if match is not None:
+        sub = match.group(1)
+        v1, v2 = match.span(1)
+        if "," in sub:
+            for pat in sub.strip('{}').split(','):
+                subpattern = pattern[:v1] + pat + pattern[v2:]
+                res.update(expand_braces(subpattern))
+        else:
+            subpattern = pattern[:v1] + remove_outer_braces(sub) + pattern[v2:]
+            res.update(expand_braces(subpattern))
     else:
-        matching = fnmatch.filter(entries, pattern)
-        matching.sort()
-        return matching
+        res.add(pattern.replace('\\}', '}'))
+
+    return list(res)

--- a/graphite_api/intervals.py
+++ b/graphite_api/intervals.py
@@ -22,6 +22,12 @@ class IntervalSet(object):
     def __iter__(self):
         return iter(self.intervals)
 
+    def __len__(self):
+        return len(self.intervals)
+
+    def __getitem__(self, i):
+        return self.intervals[i]
+
     def __bool__(self):
         return self.size != 0
     __nonzero__ = __bool__  # python 2

--- a/graphite_api/node.py
+++ b/graphite_api/node.py
@@ -16,16 +16,19 @@ class BranchNode(Node):
 
 
 class LeafNode(Node):
-    __slots__ = ('reader', 'intervals')
+    __slots__ = ('reader', 'is_leaf')
 
     def __init__(self, path, reader):
         super(LeafNode, self).__init__(path)
         self.reader = reader
-        self.intervals = reader.get_intervals()
         self.is_leaf = True
 
     def fetch(self, startTime, endTime):
         return self.reader.fetch(startTime, endTime)
+
+    @property
+    def intervals(self):
+        return self.reader.get_intervals()
 
     def __repr__(self):
         return '<LeafNode[%x]: %s (%s)>' % (id(self), self.path, self.reader)

--- a/graphite_api/node.py
+++ b/graphite_api/node.py
@@ -23,8 +23,13 @@ class LeafNode(Node):
         self.reader = reader
         self.is_leaf = True
 
-    def fetch(self, startTime, endTime):
-        return self.reader.fetch(startTime, endTime)
+    def fetch(self, startTime, endTime, now=None, requestContext=None):
+        try:
+            result = self.reader.fetch(startTime, endTime, now, requestContext)
+        except TypeError:
+            result = self.reader.fetch(startTime, endTime)
+
+        return result
 
     @property
     def intervals(self):

--- a/graphite_api/readers.py
+++ b/graphite_api/readers.py
@@ -1,4 +1,7 @@
 from .intervals import IntervalSet
+from structlog import get_logger
+
+logger = get_logger()
 
 
 class MultiReader(object):
@@ -15,7 +18,13 @@ class MultiReader(object):
 
     def fetch(self, startTime, endTime):
         # Start the fetch on each node
-        results = [n.fetch(startTime, endTime) for n in self.nodes]
+        results = []
+
+        for node in self.nodes:
+            try:
+                results.append(node.fetch(startTime, endTime))
+            except Exception:
+                logger.error("fetch error", exc_info=True)
 
         data = None
         for r in filter(None, results):

--- a/graphite_api/readers.py
+++ b/graphite_api/readers.py
@@ -16,13 +16,14 @@ class MultiReader(object):
             interval_sets.extend(node.intervals.intervals)
         return IntervalSet(sorted(interval_sets))
 
-    def fetch(self, startTime, endTime):
+    def fetch(self, startTime, endTime, now=None, requestContext=None):
         # Start the fetch on each node
         results = []
 
         for node in self.nodes:
             try:
-                results.append(node.fetch(startTime, endTime))
+                results.append(node.fetch(startTime, endTime, now,
+                                          requestContext))
             except Exception:
                 logger.error("fetch error", exc_info=True)
 

--- a/graphite_api/render/attime.py
+++ b/graphite_api/render/attime.py
@@ -21,7 +21,7 @@ months = ['jan', 'feb', 'mar', 'apr', 'may', 'jun',
 weekdays = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
 
 
-def parseATTime(s, tzinfo=None):
+def parseATTime(s, tzinfo=None, now=None):
     if tzinfo is None:
         from ..app import app
         tzinfo = pytz.timezone(app.config['TIME_ZONE'])
@@ -46,11 +46,13 @@ def parseATTime(s, tzinfo=None):
         offset = '-' + offset
     else:
         ref, offset = s, ''
-    return (parseTimeReference(ref) +
+    return (parseTimeReference(ref or now) +
             parseTimeOffset(offset)).astimezone(tzinfo)
 
 
 def parseTimeReference(ref):
+    if isinstance(ref, datetime):
+        return ref
     if not ref or ref == 'now':
         return datetime.utcnow().replace(tzinfo=pytz.utc)
 

--- a/graphite_api/render/datalib.py
+++ b/graphite_api/render/datalib.py
@@ -29,6 +29,7 @@ class TimeSeries(list):
         self.consolidationFunc = consolidate
         self.valuesPerPoint = 1
         self.options = {}
+        self.pathExpression = name
 
     def __eq__(self, other):
         if isinstance(other, TimeSeries):
@@ -190,12 +191,12 @@ def fetchData(requestContext, pathExprs):
 
     # Single fetches
     fetches = [
-        (node, node.fetch(startTime, endTime, now, requestContext))
+        (node.path, node.fetch(startTime, endTime, now, requestContext))
         for node in single_nodes
     ]
-    for node, results in fetches:
+    for path, results in fetches:
         if not results:
-            logger.info("no results", node=node, start=startTime,
+            logger.info("no results", path=path, start=startTime,
                         end=endTime)
             continue
 
@@ -203,9 +204,8 @@ def fetchData(requestContext, pathExprs):
             time_info, values = results
         except ValueError as e:
             raise Exception("could not parse timeInfo/values from metric "
-                            "'%s': %s" % (node.path, e))
-        data_store.add_data(node.path, time_info, values,
-                            path_to_exprs[node.path])
+                            "'%s': %s" % (path, e))
+        data_store.add_data(path, time_info, values, path_to_exprs[path])
 
     return data_store
 

--- a/graphite_api/render/glyph.py
+++ b/graphite_api/render/glyph.py
@@ -910,8 +910,8 @@ class Graph(object):
             numberOfLines = max(len(elements) - numRight, numRight)
             columns = math.floor(columns / 2.0)
             columns = max(columns, 1)
-            legendHeight = max(
-                1, (numberOfLines / columns)) * (lineHeight + padding)
+            legendHeight = (
+                max(1, (numberOfLines / columns)) * lineHeight) + padding
             # scoot the drawing area up to fit the legend
             self.area['ymax'] -= legendHeight
             self.ctx.set_line_width(1.0)
@@ -956,7 +956,7 @@ class Graph(object):
             columns = math.floor(self.width / labelWidth)
             columns = max(columns, 1)
             numberOfLines = math.ceil(float(len(elements)) / columns)
-            legendHeight = numberOfLines * (lineHeight + padding)
+            legendHeight = (numberOfLines * lineHeight) + padding
             # scoot the drawing area up to fit the legend
             self.area['ymax'] -= legendHeight
             self.ctx.set_line_width(1.0)

--- a/graphite_api/render/grammar.py
+++ b/graphite_api/render/grammar.py
@@ -1,24 +1,19 @@
 from distutils.version import StrictVersion
 from pyparsing import (
-    ParserElement, Forward, Combine, Optional, Word, Literal, CaselessKeyword,
+    Forward, Combine, Optional, Word, Literal, CaselessKeyword,
     CaselessLiteral, Group, FollowedBy, LineEnd, OneOrMore, ZeroOrMore,
-    nums, alphas, alphanums, printables, delimitedList, quotedString,
+    alphas, alphanums, printables, delimitedList, quotedString, Regex,
     __version__
 )
 
-ParserElement.enablePackrat()
 grammar = Forward()
 
 expression = Forward()
 
 # Literals
-intNumber = Combine(
-    Optional('-') + Word(nums)
-)('integer')
+intNumber = Regex(r'-?\d+')('integer')
 
-floatNumber = Combine(
-    Optional('-') + Word(nums) + Literal('.') + Word(nums)
-)('float')
+floatNumber = Regex(r'-?\d+\.\d+')('float')
 
 sciNumber = Combine(
     (floatNumber | intNumber) + CaselessLiteral('e') + intNumber

--- a/tests/test_carbonlink.py
+++ b/tests/test_carbonlink.py
@@ -117,6 +117,32 @@ class ConsistentHashRingTest(TestCase):
         self.assertEqual(node, expected)
 
 
+class ConsistentHashRingTestFNV1A(TestCase):
+    def test_chr_compute_ring_position_fnv1a(self):
+        hosts = [
+            ("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),
+            ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
+            ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28"),
+        ]
+        hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
+        self.assertEqual(hashring.compute_ring_position('hosts.worker1.cpu'),
+                         59573)
+        self.assertEqual(hashring.compute_ring_position('hosts.worker2.cpu'),
+                         35749)
+
+    def test_chr_get_node_fnv1a(self):
+        hosts = [
+            ("127.0.0.1", "ba603c36342304ed77953f84ac4d357b"),
+            ("127.0.0.2", "5dd63865534f84899c6e5594dba6749a"),
+            ("127.0.0.3", "866a18b81f2dc4649517a1df13e26f28"),
+        ]
+        hashring = ConsistentHashRing(hosts, hash_type='fnv1a_ch')
+        self.assertEqual(hashring.get_node('hosts.worker1.cpu'),
+                         ('127.0.0.1', 'ba603c36342304ed77953f84ac4d357b'))
+        self.assertEqual(hashring.get_node('hosts.worker2.cpu'),
+                         ('127.0.0.3', '866a18b81f2dc4649517a1df13e26f28'))
+
+
 class CarbonLinkPoolTest(TestCase):
     def test_clp_replication_factor(self):
         with self.assertRaises(Exception) as context:

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -109,6 +109,17 @@ class WhisperFinderTest(TestCase):
             nodes = store.find('whisper_finder.*.ba?.{baz,foo}')
             self.assertEqual(len(list(nodes)), 2)
             self.assertEqual(scandir_mocked.call_count, 5)
+
+            scandir_mocked.call_count = 0
+            nodes = store.find('whisper_finder.{foo,bar}.{baz,bar}.{baz,foo}')
+            self.assertEqual(len(list(nodes)), 2)
+            self.assertEqual(scandir_mocked.call_count, 5)
+
+            scandir_mocked.call_count = 0
+            nodes = store.find('whisper_finder.foo.{ba{r,z},baz}.baz')
+            self.assertEqual(len(list(nodes)), 1)
+            self.assertEqual(scandir_mocked.call_count, 1)
+
         finally:
             scandir_mocked.call_count = 0
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -21,9 +21,9 @@ class RenderTest(TestCase):
         whisper.create(self.db, [(1, 60)])
 
         self.ts = int(time.time())
-        whisper.update(self.db, 0.5, self.ts - 2)
-        whisper.update(self.db, 0.4, self.ts - 1)
-        whisper.update(self.db, 0.6, self.ts)
+        whisper.update(self.db, 1.0, self.ts - 2)
+        whisper.update(self.db, 0.5, self.ts - 1)
+        whisper.update(self.db, 1.5, self.ts)
 
     def test_render_view(self):
         response = self.app.get(self.url, query_string={'target': 'test',
@@ -61,12 +61,12 @@ class RenderTest(TestCase):
         end = data[0]['datapoints'][-4:]
         try:
             self.assertEqual(
-                end, [[None, self.ts - 3], [0.5, self.ts - 2],
-                      [0.4, self.ts - 1], [0.6, self.ts]])
+                end, [[None, self.ts - 3], [1.0, self.ts - 2],
+                      [0.5, self.ts - 1], [1.5, self.ts]])
         except AssertionError:
             self.assertEqual(
-                end, [[0.5, self.ts - 2], [0.4, self.ts - 1],
-                      [0.6, self.ts], [None, self.ts + 1]])
+                end, [[1.0, self.ts - 2], [0.5, self.ts - 1],
+                      [1.5, self.ts], [None, self.ts + 1]])
 
         response = self.app.get(self.url, query_string={'target': 'test',
                                                         'maxDataPoints': 2,
@@ -87,9 +87,9 @@ class RenderTest(TestCase):
                                                         'format': 'json'})
         data = json.loads(response.data.decode('utf-8'))
         self.assertEqual(data[0]['datapoints'],
-                         [[0.5, self.ts - 2],
-                          [0.4, self.ts - 1],
-                          [0.6, self.ts]])
+                         [[1.0, self.ts - 2],
+                          [0.5, self.ts - 1],
+                          [1.5, self.ts]])
 
         response = self.app.get(self.url, query_string={'target': 'test',
                                                         'format': 'raw'})
@@ -97,12 +97,12 @@ class RenderTest(TestCase):
             self.assertEqual(
                 response.data.decode('utf-8'),
                 'test,%d,%d,1|%s' % (self.ts - 59, self.ts + 1,
-                                     'None,' * 57 + '0.5,0.4,0.6\n'))
+                                     'None,' * 57 + '1.0,0.5,1.5\n'))
         except AssertionError:
             self.assertEqual(
                 response.data.decode('utf-8'),
                 'test,%d,%d,1|%s' % (self.ts - 58, self.ts + 2,
-                                     'None,' * 56 + '0.5,0.4,0.6,None\n'))
+                                     'None,' * 56 + '1.0,0.5,1.5,None\n'))
 
         response = self.app.get(self.url, query_string={'target': 'test',
                                                         'format': 'dygraph'})
@@ -111,14 +111,14 @@ class RenderTest(TestCase):
         try:
             self.assertEqual(
                 end, [[(self.ts - 3) * 1000, None],
-                      [(self.ts - 2) * 1000, 0.5],
-                      [(self.ts - 1) * 1000, 0.4],
-                      [self.ts * 1000, 0.6]])
+                      [(self.ts - 2) * 1000, 1.0],
+                      [(self.ts - 1) * 1000, 0.5],
+                      [self.ts * 1000, 1.5]])
         except AssertionError:
             self.assertEqual(
-                end, [[(self.ts - 2) * 1000, 0.5],
-                      [(self.ts - 1) * 1000, 0.4],
-                      [self.ts * 1000, 0.6],
+                end, [[(self.ts - 2) * 1000, 1.0],
+                      [(self.ts - 1) * 1000, 0.5],
+                      [self.ts * 1000, 1.5],
                       [(self.ts + 1) * 1000, None]])
 
         response = self.app.get(self.url, query_string={'target': 'test',
@@ -128,14 +128,14 @@ class RenderTest(TestCase):
         try:
             self.assertEqual(
                 end, [{'x': self.ts - 3, 'y': None},
-                      {'x': self.ts - 2, 'y': 0.5},
-                      {'x': self.ts - 1, 'y': 0.4},
-                      {'x': self.ts, 'y': 0.6}])
+                      {'x': self.ts - 2, 'y': 1.0},
+                      {'x': self.ts - 1, 'y': 0.5},
+                      {'x': self.ts, 'y': 1.5}])
         except AssertionError:
             self.assertEqual(
-                end, [{'x': self.ts - 2, 'y': 0.5},
-                      {'x': self.ts - 1, 'y': 0.4},
-                      {'x': self.ts, 'y': 0.6},
+                end, [{'x': self.ts - 2, 'y': 1.0},
+                      {'x': self.ts - 1, 'y': 0.5},
+                      {'x': self.ts, 'y': 1.5},
                       {'x': self.ts + 1, 'y': None}])
 
     def test_render_constant_line(self):


### PR DESCRIPTION
This merges new functions and API features from graphite-web 1.0.1.

One thing I haven't done was a bug-fix for preventing repeated series evaluations for `hitcount` and `smartSummarize`.  However I'm not so sure that graphite-api suffers from the same problem.