### PR TITLE
Specify minorY default

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1006,6 +1006,9 @@ Example::
 minorY
 ``````
 
+
+*Default: 1*
+
 Sets the number of minor grid lines per major line on the y-axis.
 
 Example::


### PR DESCRIPTION
As per https://github.com/brutasse/graphite-api/blob/master/graphite_api/render/glyph.py#L715:
The default for `minorY ` seems to be `1`.