### PR TITLE
Add sumSeriesWithRegex function

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -243,8 +243,7 @@ def sumSeriesWithRegex(requestContext, seriesList, pos, reg):
     kafkaimport2-test2
 
     """
-    newSeries = {}
-    newNames = list()
+    newSeries = defaultdict(list)
 
     for series in seriesList:
         newname = series.name.split('.')[pos]
@@ -253,15 +252,15 @@ def sumSeriesWithRegex(requestContext, seriesList, pos, reg):
         if result:
             newname = "-".join(result.groups())
 
-        if newname in newSeries:
-            newSeries[newname] = sumSeries(requestContext,
-                                           (series, newSeries[newname]))[0]
-        else:
-            newSeries[newname] = series
-            newNames.append(newname)
-        newSeries[newname].name = newname
+        newSeries[newname].append(series)
 
-    return [newSeries[name] for name in newNames]
+    ret = []
+    for name, series in newSeries.items():
+        summedSeries = sumSeries(requestContext, series)[0]
+        summedSeries.name = name
+        ret.append(summedSeries)
+
+    return ret
 
 
 def sumSeriesWithWildcards(requestContext, seriesList, *positions):

--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -226,15 +226,21 @@ def sumSeriesWithRegex(requestContext, seriesList, pos, reg):
 
     Example:
 
-    sumSeriesWithRegex(*.kafka.group-$consumer_group-$topic-*.consumed.AVERAGE, 2, "group
--(.*?)-(.*?)-.*")
+    sumSeriesWithRegex(
+        *.kafka.group-$consumer_group-$topic-*.consumed.AVERAGE,
+        2,
+        "group-(.*?)-(.*?)-.*"
+    )
 
     with:
     $consumer_group = {kafkaimport1, kafkaimport2}
     $topic = {test1, test2}
 
     results in 4 sumSeries:
-    kafkaimport1-test1, kafkaimport1-test2, kafkaimport2-test1, kafkaimport2-test2
+    kafkaimport1-test1,
+    kafkaimport1-test2,
+    kafkaimport2-test1,
+    kafkaimport2-test2
 
     """
     newSeries = {}
@@ -249,7 +255,7 @@ def sumSeriesWithRegex(requestContext, seriesList, pos, reg):
 
         if newname in newSeries:
             newSeries[newname] = sumSeries(requestContext,
-                                        (series, newSeries[newname]))[0]
+                                           (series, newSeries[newname]))[0]
         else:
             newSeries[newname] = series
             newNames.append(newname)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -867,7 +867,8 @@ class FunctionsTest(TestCase):
             TimeSeries('collectd.test1.metric-cat2-0', 0, 1, 1, [None]),
             TimeSeries('collectd.test1.metric-cat2-1', 0, 1, 1, [None]),
         ]
-        sum_ = functions.sumSeriesWithRegex({}, seriesList, 2, "metric-(.*?)-.*")
+        reg = "metric-(.*?)-.*"
+        sum_ = functions.sumSeriesWithRegex({}, seriesList, 2, reg)
         expected = [
             TimeSeries('cat1', 0, 1, 1, [None]),
             TimeSeries('cat2', 0, 1, 1, [None]),

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -847,6 +847,33 @@ class FunctionsTest(TestCase):
                          "collectd.test-db4.load.value)")
         self.assertEqual(sum_[:3], [3, 5, 6])
 
+    def test_sum_series_regex_empty_series_int_position(self):
+        self.assertEqual(functions.sumSeriesWithRegex({}, [], 0, ""), [])
+
+    def test_sum_series_regex_not_found(self):
+        seriesList = [
+            TimeSeries('collectd.test1.metric-cat1-0', 0, 1, 1, [None]),
+            TimeSeries('collectd.test1.metric-cat1-1', 0, 1, 1, [None]),
+            TimeSeries('collectd.test1.metric-cat2-0', 0, 1, 1, [None]),
+            TimeSeries('collectd.test1.metric-cat2-1', 0, 1, 1, [None]),
+        ]
+        sum_ = functions.sumSeriesWithRegex({}, seriesList, 2, "randomregex")
+        self.assertEqual(sum_, seriesList)
+
+    def test_sum_series_regex(self):
+        seriesList = [
+            TimeSeries('collectd.test1.metric-cat1-0', 0, 1, 1, [None]),
+            TimeSeries('collectd.test1.metric-cat1-1', 0, 1, 1, [None]),
+            TimeSeries('collectd.test1.metric-cat2-0', 0, 1, 1, [None]),
+            TimeSeries('collectd.test1.metric-cat2-1', 0, 1, 1, [None]),
+        ]
+        sum_ = functions.sumSeriesWithRegex({}, seriesList, 2, "metric-(.*?)-.*")
+        expected = [
+            TimeSeries('cat1', 0, 1, 1, [None]),
+            TimeSeries('cat2', 0, 1, 1, [None]),
+        ]
+        self.assertEqual(sum_, expected)
+
     def test_sum_series_wildcards_empty_series_int_position(self):
         self.assertEqual(functions.sumSeriesWithWildcards({}, [], 0), [])
 


### PR DESCRIPTION
This allows to sum different series by variables within a node.
Example:
collectd.test1.metric-{cat1, cat2}-\*

might become:
sumSeries(collectd.test1.metric-cat1-\*)
sumSeries(collectd.test1.metric-cat2-\*)

This is a little bit different than sumSeriesWithWildcards, which only allows specifying a node.