### PR TITLE
fix legacy target array

### DIFF
--- a/graphite_api/app.py
+++ b/graphite_api/app.py
@@ -270,6 +270,11 @@ def render():
                 graph_type, "', '".join(sorted(GraphTypes))))
     request_options['pieMode'] = RequestParams.get('pieMode', 'average')
     targets = RequestParams.getlist('target')
+
+    # Rails/PHP/jQuery common practice format: ?target[]=path.1&target[]=path.2
+    if not len(targets):
+        targets = RequestParams.getlist('target[]')
+
     if not len(targets):
         errors['target'] = 'This parameter is required.'
     request_options['targets'] = targets


### PR DESCRIPTION
In legacy libs they use target args as array.

I discovery the issue integrating NSQ.io with graphite-api+influxgraph