### PR TITLE
functions: Don't sort series in formatPathExpressions.

### DIFF
--- a/graphite_api/functions.py
+++ b/graphite_api/functions.py
@@ -186,7 +186,9 @@ def formatPathExpressions(seriesList):
     """
     Returns a comma-separated list of unique path expressions.
     """
-    pathExpressions = sorted(set([s.pathExpression for s in seriesList]))
+    pathExpressions = []
+    [pathExpressions.append(s.pathExpression)
+     for s in seriesList if not pathExpressions.count(s.pathExpression)]
     return ','.join(pathExpressions)
 
 # Series Functions

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -856,8 +856,8 @@ class FunctionsTest(TestCase):
         self.assertEqual(sum_.pathExpression,
                          "sumSeries(collectd.test-db4.load.value,"
                          "sumSeries(collectd.test-db3.load.value,"
-                         "sumSeries(collectd.test-db1.load.value,"
-                         "collectd.test-db2.load.value)))")
+                         "sumSeries(collectd.test-db2.load.value,"
+                         "collectd.test-db1.load.value)))")
         self.assertEqual(sum_[:3], [3, 5, 6])
 
     def test_diff_series_empty(self):
@@ -867,6 +867,9 @@ class FunctionsTest(TestCase):
     def test_diff_series(self):
         series = self._generate_series_list()[:2]
         diff = functions.diffSeries({}, [series[0]], [series[1]])[0]
+        self.assertEqual(diff.pathExpression,
+                         "diffSeries(collectd.test-db1.load.value,"
+                         "collectd.test-db2.load.value)")
         self.assertEqual(diff[:3], [-2, -2, -2])
 
     def test_average_series_empty(self):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -192,7 +192,7 @@ class RenderTest(TestCase):
         for series in data:
             agg[series['target']] = series['datapoints']
         for index, value in enumerate(agg['baz']):
-            self.assertEqual(value, agg['sumSeries(sin(bar),sin(foo))'][index])
+            self.assertEqual(value, agg['sumSeries(sin(foo),sin(bar))'][index])
 
         response = self.app.get(self.url, query_string={
             'target': ['sumSeries(sin("foo"), sin("bar", 2))',
@@ -206,7 +206,7 @@ class RenderTest(TestCase):
             self.assertTrue(len(series['datapoints']) <= 100)
             agg[series['target']] = series['datapoints']
         for index, value in enumerate(agg['baz']):
-            self.assertEqual(value, agg['sumSeries(sin(bar),sin(foo))'][index])
+            self.assertEqual(value, agg['sumSeries(sin(foo),sin(bar))'][index])
 
     def test_correct_timezone(self):
         response = self.app.get(self.url, query_string={


### PR DESCRIPTION
This is a cause of confusion when you request 'diff(foo, bar)', but the legend says 'diff(bar, foo)'