### PR TITLE
graphite_api: .zone attribute is not supported anymore

### DIFF
--- a/graphite_api/config.py
+++ b/graphite_api/config.py
@@ -37,7 +37,7 @@ default_conf = {
             '/srv/graphite/whisper',
         ],
     },
-    'time_zone': get_localzone().zone,
+    'time_zone': str(get_localzone()),
 }
 if default_conf['time_zone'] == 'local':  # tzlocal didn't find anything
     default_conf['time_zone'] = 'UTC'


### PR DESCRIPTION
gunicorn3[308238]: File "/usr/lib/python3/dist-packages/graphite_api/config.py", line 45, in <module>
gunicorn3[308238]: 'time_zone': get_localzone().zone,
gunicorn3[308238]: AttributeError: 'zoneinfo.ZoneInfo' object has no attribute 'zone'